### PR TITLE
216 color order mismatch in divider component

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...develop)
 
+### Fixed
+
+- [DemoApp] Color order mismatch in `Divider` component ([#216](https://github.com/Orange-OpenSource/ouds-flutter/issues/216))
+
 ## [0.3.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.2.0...0.3.0) - 2025-06-10
 
 ### Added

--- a/app/lib/ui/components/divider/divider_customization.dart
+++ b/app/lib/ui/components/divider/divider_customization.dart
@@ -65,19 +65,19 @@ class ColorState {
   final void Function(void Function()) _setState;
 
   List<DividerEnumColor> _color = [
-    DividerEnumColor.alwaysOnWhite,
+    DividerEnumColor.defaultColor,
+    DividerEnumColor.muted,
+    DividerEnumColor.emphasized,
+    DividerEnumColor.brandPrimary,
+    DividerEnumColor.onBrandPrimary,
+    DividerEnumColor.alwaysBlack,
     DividerEnumColor.alwaysWhite,
     DividerEnumColor.alwaysOnBlack,
-    DividerEnumColor.alwaysBlack,
-    DividerEnumColor.brandPrimary,
-    DividerEnumColor.defaultColor,
-    DividerEnumColor.emphasized,
-    DividerEnumColor.muted,
-    DividerEnumColor.onBrandPrimary,
+    DividerEnumColor.alwaysOnWhite,
   ];
 
   DividerEnumColor _selectedColor = DividerEnumColor.defaultColor;
-  int _selectedIndex = 5;
+  int _selectedIndex = 0;
 
   List<DividerEnumColor> get list => _color;
   set list(List<DividerEnumColor> newList) {

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -62,8 +62,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
   Widget build(BuildContext context) {
     final DividerCustomizationState? customizationState = DividerCustomization.of(context);
 
-    //sort alphabetic order
-    var colors = customizationState!.colorState.list..sort((color, colorNext) => color.formattedName.compareTo(colorNext.formattedName));
+    var colors = customizationState!.colorState.list;
 
     return CustomizationDropdownMenu<DividerEnumColor>(
       label: DividerEnumColor.enumName(context),

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -25,21 +25,31 @@ class DividerDemoScreen extends StatefulWidget {
 }
 
 class _DividerDemoScreenState extends State<DividerDemoScreen> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  bool _isBottomSheetExpanded = false;
+
+  void _onExpansionChanged(bool isExpanded) {
+    setState(() {
+      _isBottomSheetExpanded = isExpanded;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return DividerCustomization(
         child: Scaffold(
       bottomSheet: OudsSheetsBottom(
+        onExpansionChanged: _onExpansionChanged,
         sheetContent: const _CustomizationContent(),
         title: context.l10n.app_common_customize_label,
       ),
-      // key: _scaffoldKey,
+      key: _scaffoldKey,
       appBar: widget.vertical
-          ? MainAppBar(title: context.l10n.app_components_divider_verticalDivider_label) // Display IndeterminateCheckboxDemo if true
+          ? MainAppBar(title: context.l10n.app_components_divider_verticalDivider_label)
           : MainAppBar(title: context.l10n.app_components_divider_horizontalDivider_label),
       body: SafeArea(
         child: ExcludeSemantics(
-          //excluding: !_isBottomSheetExpanded,
+          excluding: !_isBottomSheetExpanded,
           child: _Body(vertical: widget.vertical),
         ),
       ),

--- a/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
+++ b/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
@@ -10,6 +10,7 @@
 // Software description: Flutter library of reusable graphical components
 //
 import 'package:flutter/material.dart';
+import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/ui/theme/theme_controller.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
@@ -44,39 +45,54 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: EdgeInsetsDirectional.symmetric(horizontal: currentTheme.spaceScheme(context).fixedMedium),
-          child: Text(
-            label,
-            style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+        ExcludeSemantics(
+          child: Padding(
+            padding: EdgeInsetsDirectional.symmetric(horizontal: currentTheme.spaceScheme(context).fixedMedium),
+            child: Text(
+              label,
+              style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+            ),
           ),
         ),
         Padding(
           padding: EdgeInsetsDirectional.symmetric(
-              horizontal: currentTheme.spaceScheme(context).fixedMedium, vertical: currentTheme.spaceScheme(context).fixedShorter),
-          child: DropdownMenu<T>(
-            initialSelection: options[selectedItemIndex],
-            expandedInsets: EdgeInsets.zero,
-            inputDecorationTheme: const InputDecorationTheme(isDense: true),
-            textStyle: currentTheme.typographyTokens.typeBodyStrongLarge(context),
-            onSelected: (value) {
-              if (value != null) {
-                final newIndex = options.indexOf(value);
-                onSelectionChange(value, newIndex);
-              }
-            },
-            leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, selectedItemIndex) : null,
-            dropdownMenuEntries: List.generate(options.length, (index) {
-              return DropdownMenuEntry<T>(
-                labelWidget: Text(
-                  getText(options[index]),
-                  style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
-                ),
-                value: options[index],
-                label: getText(options[index]),
-                leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, index) : null,
-              );
-            }),
+            horizontal: currentTheme.spaceScheme(context).fixedMedium,
+            vertical: currentTheme.spaceScheme(context).fixedShorter,
+          ),
+          child: Semantics(
+            selected: options.contains(options[selectedItemIndex]),
+            child: DropdownMenu<T>(
+              initialSelection: options[selectedItemIndex],
+              expandedInsets: EdgeInsets.zero,
+              inputDecorationTheme: const InputDecorationTheme(isDense: true),
+              textStyle: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+              onSelected: (value) {
+                if (value != null) {
+                  final newIndex = options.indexOf(value);
+                  onSelectionChange(value, newIndex);
+                }
+              },
+              leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, selectedItemIndex) : null,
+              dropdownMenuEntries: List.generate(
+                options.length,
+                (index) {
+                  final isSelected = options[index] == options[selectedItemIndex];
+                  return DropdownMenuEntry<T>(
+                    labelWidget: Semantics(
+                      button: true,
+                      value: isSelected ? context.l10n.app_common_selected_a11y : context.l10n.app_common_unselected_a11y,
+                      child: Text(
+                        getText(options[index]),
+                        style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+                      ),
+                    ),
+                    value: options[index],
+                    label: getText(options[index]),
+                    leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, index) : null,
+                  );
+                },
+              ),
+            ),
           ),
         ),
       ],

--- a/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
+++ b/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
@@ -40,6 +40,7 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeController = Provider.of<ThemeController>(context, listen: false);
     final currentTheme = themeController.currentTheme;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -47,24 +48,17 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
           padding: EdgeInsetsDirectional.symmetric(horizontal: currentTheme.spaceScheme(context).fixedMedium),
           child: Text(
             label,
-            style: TextStyle(
-              fontSize: themeController.currentTheme.fontTokens.sizeBodyLargeMobile,
-              fontWeight: themeController.currentTheme.fontTokens.weightLabelStrong,
-              letterSpacing: themeController.currentTheme.fontTokens.letterSpacingBodyLargeMobile,
-            ),
+            style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
           ),
         ),
         Padding(
-          padding: EdgeInsetsDirectional.symmetric(horizontal: currentTheme.spaceScheme(context).fixedMedium, vertical: currentTheme.spaceScheme(context).fixedShorter),
+          padding: EdgeInsetsDirectional.symmetric(
+              horizontal: currentTheme.spaceScheme(context).fixedMedium, vertical: currentTheme.spaceScheme(context).fixedShorter),
           child: DropdownMenu<T>(
             initialSelection: options[selectedItemIndex],
             expandedInsets: EdgeInsets.zero,
             inputDecorationTheme: const InputDecorationTheme(isDense: true),
-            textStyle: TextStyle(
-              fontSize: OudsTheme.of(context).fontTokens.sizeBodyLargeMobile,
-              fontWeight: OudsTheme.of(context).fontTokens.weightLabelStrong,
-              letterSpacing: OudsTheme.of(context).fontTokens.letterSpacingBodyLargeMobile,
-            ),
+            textStyle: currentTheme.typographyTokens.typeBodyStrongLarge(context),
             onSelected: (value) {
               if (value != null) {
                 final newIndex = options.indexOf(value);
@@ -74,12 +68,10 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
             leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, selectedItemIndex) : null,
             dropdownMenuEntries: List.generate(options.length, (index) {
               return DropdownMenuEntry<T>(
-                labelWidget: Text(getText(options[index]),
-                    style: TextStyle(
-                      fontSize: OudsTheme.of(context).fontTokens.sizeBodyLargeMobile,
-                      fontWeight: OudsTheme.of(context).fontTokens.weightLabelStrong,
-                      letterSpacing: OudsTheme.of(context).fontTokens.letterSpacingBodyLargeMobile,
-                    )),
+                labelWidget: Text(
+                  getText(options[index]),
+                  style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+                ),
                 value: options[index],
                 label: getText(options[index]),
                 leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, index) : null,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -611,5 +611,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [x] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
