### PR TITLE
220 bug delayed pressed state on long texts

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [DemoApp] Add token version in About page and documentation ([#142](https://github.com/Orange-OpenSource/ouds-flutter/issues/#142))
-- 
+
 ### Fixed
 
+- [DemoApp][Library] Delayed pressed state ([#220](https://github.com/Orange-OpenSource/ouds-flutter/issues/220))
 - [DemoApp] Update cards backgrounds token ([#204](https://github.com/Orange-OpenSource/ouds-flutter/issues/204))
 - [DemoApp][Library] Token `size` values now adapt based on device type ([#218](https://github.com/Orange-OpenSource/ouds-flutter/issues/218))
 - [DemoApp] Color order mismatch in `Divider` component ([#216](https://github.com/Orange-OpenSource/ouds-flutter/issues/216))

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...develop)
 
+### Fixed
+- [Library] Delayed pressed state ([#220](https://github.com/Orange-OpenSource/ouds-flutter/issues/220))
+
 ## [0.3.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.2.0...0.3.0) - 2025-06-10
 
 ### Added

--- a/ouds_core/lib/components/button/internal/button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_background_modifier.dart
@@ -21,6 +21,7 @@ class ButtonBackgroundModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
+    bool isPressed,
   ) {
     return WidgetStateProperty.resolveWith<Color?>(
       (Set<WidgetState> states) {
@@ -28,7 +29,7 @@ class ButtonBackgroundModifier {
           return ButtonLoadingModifier.getBackgroundToken(context, hierarchy);
         }
 
-        if (states.contains(WidgetState.pressed)) {
+        if (states.contains(WidgetState.pressed) || isPressed) {
           return _getPressedColor(context, hierarchy);
         } else if (states.contains(WidgetState.hovered)) {
           return _getHoverColor(context, hierarchy);

--- a/ouds_core/lib/components/button/internal/button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_foreground_modifier.dart
@@ -21,6 +21,7 @@ class ButtonForegroundModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
+    bool isPressed,
   ) {
     return WidgetStateProperty.resolveWith<Color?>(
       (Set<WidgetState> states) {
@@ -28,7 +29,7 @@ class ButtonForegroundModifier {
           return ButtonLoadingModifier.getColorToken(context, hierarchy);
         }
 
-        if (states.contains(WidgetState.pressed)) {
+        if (states.contains(WidgetState.pressed) || isPressed) {
           return _getPressedForegroundColor(context, hierarchy);
         } else if (states.contains(WidgetState.hovered)) {
           return _getHoverForegroundColor(context, hierarchy);

--- a/ouds_core/lib/components/button/internal/button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_style_modifier.dart
@@ -24,6 +24,7 @@ class ButtonStyleModifier {
     required OudsButtonHierarchy hierarchy,
     required OudsButtonLayout layout,
     OudsButtonStyle? style,
+    required bool isPressed,
   }) {
     double iconSize;
     if (layout == OudsButtonLayout.iconOnly) {
@@ -33,11 +34,10 @@ class ButtonStyleModifier {
     } else {
       iconSize = 0.0;
     }
-
     return ButtonStyle(
-      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style),
-      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style),
-      iconColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style),
+      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, isPressed),
+      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
+      iconColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
       splashFactory: NoSplash.splashFactory,
       overlayColor: WidgetStateProperty.all(Colors.transparent),
       iconSize: WidgetStateProperty.all<double>(iconSize),

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -10,6 +10,7 @@
 //
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:ouds_core/components/button/internal/button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/button_style_modifier.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
@@ -111,6 +112,25 @@ class OudsButton extends StatefulWidget {
 }
 
 class _OudsButtonState extends State<OudsButton> {
+  bool _isPressed = false;
+
+  // Added to improve visual rendering fluidity by allowing Flutter
+  // to complete the current frame before executing the onPressed callback.
+  void _handlePressed(VoidCallback? callback) {
+    setState(() {
+      _isPressed = true;
+    });
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      callback?.call();
+      if (mounted) {
+        setState(() {
+          _isPressed = false;
+        });
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     try {
@@ -137,8 +157,8 @@ class _OudsButtonState extends State<OudsButton> {
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadius),
           child: OutlinedButton(
-            onPressed: widget.onPressed,
-            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style),
+            onPressed: () => _handlePressed(widget.onPressed),
+            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
             child: Stack(
               alignment: Alignment.center,
               children: [
@@ -168,7 +188,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style),
+              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
               child: Stack(
                 alignment: Alignment.center,
                 children: [
@@ -212,8 +232,8 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: ExcludeSemantics(
             child: IconButton(
-              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout),
-              onPressed: widget.onPressed,
+              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
+              onPressed: () => _handlePressed(widget.onPressed),
               icon: widget.icon!,
             ),
           ),
@@ -224,7 +244,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: IconButton(
             onPressed: null,
-            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style),
+            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
             icon: Stack(
               alignment: Alignment.center,
               children: [
@@ -246,8 +266,8 @@ class _OudsButtonState extends State<OudsButton> {
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadius),
           child: OutlinedButton(
-            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout),
-            onPressed: widget.onPressed,
+            style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
+            onPressed: () => _handlePressed(widget.onPressed),
             child: Text(
               widget.label ?? "",
               textAlign: TextAlign.center,
@@ -261,7 +281,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style),
+              style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/ouds_core/lib/components/checkbox/ouds_checkbox.dart
+++ b/ouds_core/lib/components/checkbox/ouds_checkbox.dart
@@ -10,6 +10,7 @@
 //
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:ouds_core/components/control/internal/interaction/ouds_inherited_interaction_model.dart';
 import 'package:ouds_core/components/control/internal/modifier/ouds_control_background_modifier.dart';
@@ -111,20 +112,27 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
           child: InkWell(
             onTap: widget.onChanged != null
                 ? () {
-                    bool? newValue;
-                    if (widget.tristate) {
-                      // Cycle through false -> true -> null
-                      if (widget.value == true) {
-                        newValue = null; // From true to null
-                      } else if (widget.value == null) {
-                        newValue = false; // From null to false
+                    _isPressed = true;
+                    // Added to improve visual rendering fluidity by allowing Flutter
+                    // to complete the current frame before executing the state change logic.
+                    SchedulerBinding.instance.addPostFrameCallback((_) {
+                      bool? newValue;
+                      if (widget.tristate) {
+                        if (widget.value == true) {
+                          newValue = null;
+                        } else if (widget.value == null) {
+                          newValue = false;
+                        } else {
+                          newValue = true;
+                        }
                       } else {
-                        newValue = true; // From false to true
+                        newValue = !widget.value!;
                       }
-                    } else {
-                      newValue = !widget.value!; // Toggle between true and false
-                    }
-                    widget.onChanged!(newValue);
+
+                      widget.onChanged!(newValue);
+
+                      _isPressed = false;
+                    });
                   }
                 : null,
             splashColor: Colors.transparent,

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ouds_core/components/control/internal/controller/ouds_interaction_state_controller.dart';
 import 'package:ouds_core/components/control/internal/interaction/ouds_inherited_interaction_model.dart';
@@ -124,7 +125,17 @@ class OudsControlItemState extends State<OudsControlItem> {
                     minWidth: OudsTheme.of(context).componentsTokens(context).controlItem.sizeMinWidth,
                   ),
                   child: InkWell(
-                    onTap: !widget.readOnly ? widget.onTap : null,
+                    onTap: !widget.readOnly
+                        ? () {
+                            interactionState.setPressed(true);
+                            // Added to improve visual rendering fluidity by allowing Flutter
+                            // to complete the current frame before executing the state change logic.
+                            SchedulerBinding.instance.addPostFrameCallback((_) {
+                              widget.onTap?.call();
+                              interactionState.setPressed(false);
+                            });
+                          }
+                        : null,
                     onHighlightChanged: interactionState.setPressed,
                     onHover: interactionState.setHovered,
                     highlightColor: Colors.transparent,

--- a/ouds_core/lib/components/radio_button/ouds_radio_button.dart
+++ b/ouds_core/lib/components/radio_button/ouds_radio_button.dart
@@ -12,6 +12,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ouds_core/components/control/internal/interaction/ouds_inherited_interaction_model.dart';
 import 'package:ouds_core/components/control/internal/modifier/ouds_control_background_modifier.dart';
@@ -109,7 +110,17 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
     return SizedBox(
       width: radioButton.sizeMaxHeight,
       child: InkWell(
-        onTap: widget.onChanged != null ? () => widget.onChanged!(widget.value) : null,
+        onTap: widget.onChanged != null
+            ? () {
+                _isPressed = true;
+                // Added to improve visual rendering fluidity by allowing Flutter
+                // to complete the current frame before executing the onChanged callback.
+                SchedulerBinding.instance.addPostFrameCallback((_) {
+                  widget.onChanged!(widget.value);
+                  _isPressed = false;
+                });
+              }
+            : null,
         splashColor: Colors.transparent,
         onHover: (hovering) {
           setState(() {


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#220 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
