### PR TITLE
feat: add themeboxcolored for lightDark mode

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...develop)
 
 ### Added
+- [DemoApp] Display components in both light/dark mode ([#223](https://github.com/Orange-OpenSource/ouds-flutter/issues/223))
 - [DemoApp] Add token version in About page and documentation ([#142](https://github.com/Orange-OpenSource/ouds-flutter/issues/#142))
-- [Tool] Display components in both light/dark mode ([#223](https://github.com/Orange-OpenSource/ouds-flutter/issues/223))
 
 ### Changed
 - [DemoApp][Library] Update tokens 1.1.0 ([#225](https://github.com/Orange-OpenSource/ouds-flutter/issues/225))

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [DemoApp] Add token version in About page and documentation ([#142](https://github.com/Orange-OpenSource/ouds-flutter/issues/#142))
+- [Tool] Display components in both light/dark mode ([#223](https://github.com/Orange-OpenSource/ouds-flutter/issues/223))
 
 ### Changed
 - [DemoApp][Library] Update tokens 1.1.0 ([#225](https://github.com/Orange-OpenSource/ouds-flutter/issues/225))
 
 ### Fixed
-
 - [DemoApp][Library] Delayed pressed state ([#220](https://github.com/Orange-OpenSource/ouds-flutter/issues/220))
 - [DemoApp] Update cards backgrounds token ([#204](https://github.com/Orange-OpenSource/ouds-flutter/issues/204))
 - [DemoApp][Library] Token `size` values now adapt based on device type ([#218](https://github.com/Orange-OpenSource/ouds-flutter/issues/218))

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -85,7 +85,7 @@ class _BodyState extends State<_Body> {
       widget: Column(
         children: [
           _ButtonDemo(),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedTall),
+          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
           Code(
             code: ButtonCodeGenerator.updateCode(context),
           ),

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -127,7 +127,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
         ),
       );
     } else {
-      return CustomizableSection(
+      return Column(
         children: [
           /// [themeMode] we test here theme of system and inverse theme mode if is not dark
           ThemeBox(

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -127,7 +127,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
         ),
       );
     } else {
-      return Column(
+      return CustomizableSection(
         children: [
           /// [themeMode] we test here theme of system and inverse theme mode if is not dark
           ThemeBox(

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -108,7 +108,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
   @override
   Widget build(BuildContext context) {
     customizationState = ButtonCustomization.of(context);
-    themeController = Provider.of<ThemeController>(context, listen: false);
+    themeController = Provider.of<ThemeController>(context, listen: true);
 
     // Adding post-frame callback to update theme based on customization state
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -27,6 +27,7 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
 
 /// This screen displays a button demo and allows customization of button properties
@@ -84,7 +85,7 @@ class _BodyState extends State<_Body> {
       widget: Column(
         children: [
           _ButtonDemo(),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
+          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedTall),
           Code(
             code: ButtonCodeGenerator.updateCode(context),
           ),
@@ -114,16 +115,46 @@ class _ButtonDemoState extends State<_ButtonDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return OudsColoredBox(
-      color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
-      child: OudsButton(
-        label: ButtonCustomizationUtils.getText(customizationState),
-        icon: ButtonCustomizationUtils.getIcon(customizationState),
-        hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
-        style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
-        onPressed: customizationState?.hasEnabled == true ? () {} : null,
-      ),
-    );
+    if (customizationState?.hasOnColoredBox == true) {
+      return OudsColoredBox(
+        color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
+        child: OudsButton(
+          label: ButtonCustomizationUtils.getText(customizationState),
+          icon: ButtonCustomizationUtils.getIcon(customizationState),
+          hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
+          style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
+          onPressed: customizationState?.hasEnabled == true ? () {} : null,
+        ),
+      );
+    } else {
+      return Column(
+        children: [
+          /// [themeMode] we test here theme of system and inverse theme mode if is not dark
+          ThemeBox(
+            themeContract: themeController!.currentTheme,
+            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+            child: OudsButton(
+              label: ButtonCustomizationUtils.getText(customizationState),
+              icon: ButtonCustomizationUtils.getIcon(customizationState),
+              hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
+              style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
+              onPressed: customizationState?.hasEnabled == true ? () {} : null,
+            ),
+          ),
+          ThemeBox(
+            themeContract: themeController!.currentTheme,
+            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+            child: OudsButton(
+              label: ButtonCustomizationUtils.getText(customizationState),
+              icon: ButtonCustomizationUtils.getIcon(customizationState),
+              hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
+              style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
+              onPressed: customizationState?.hasEnabled == true ? () {} : null,
+            ),
+          )
+        ],
+      );
+    }
   }
 }
 

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -22,9 +22,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
-
-import '../../utilities/theme_colored_box.dart';
 
 /// This screen displays a checkbox demo and allows customization of checkbox properties
 class CheckboxDemoScreen extends StatefulWidget {

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -127,7 +127,7 @@ class _CheckboxDemoState extends State<_CheckboxDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return Column(
+    return CustomizableSection(
       children: [
         ThemeBox(
           themeContract: themeController!.currentTheme,

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -12,7 +12,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/checkbox/ouds_checkbox.dart';
-import 'package:ouds_core/components/ouds_colored_box.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
 import 'package:ouds_flutter_demo/ui/components/checkbox/checkbox_code_generator.dart';
@@ -24,6 +23,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
 import 'package:provider/provider.dart';
+
+import '../../utilities/theme_colored_box.dart';
 
 /// This screen displays a checkbox demo and allows customization of checkbox properties
 class CheckboxDemoScreen extends StatefulWidget {
@@ -110,47 +111,91 @@ class _CheckboxDemo extends StatefulWidget {
 }
 
 class _CheckboxDemoState extends State<_CheckboxDemo> {
-  ThemeController? themeController;
   bool? isCheckedFirst = false;
   bool? isCheckedSecond = false;
 
   CheckboxCustomizationState? customizationState;
+  ThemeController? themeController;
 
   @override
   Widget build(BuildContext context) {
     customizationState = CheckboxCustomization.of(context);
+    themeController = Provider.of<ThemeController>(context, listen: false);
 
-    return OudsColoredBox(
-      color: OudsColoredBoxColor.statusNeutralMuted,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          OudsCheckbox(
-            value: isCheckedFirst,
-            onChanged: customizationState?.hasEnabled == true
-                ? (bool? newValue) {
-                    setState(() {
-                      isCheckedFirst = newValue;
-                    });
-                  }
-                : null,
-            isError: customizationState!.hasError,
-            tristate: widget.indeterminate,
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
+
+    return Column(
+      children: [
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OudsCheckbox(
+                value: isCheckedFirst,
+                onChanged: customizationState?.hasEnabled == true
+                    ? (bool? newValue) {
+                        setState(() {
+                          isCheckedFirst = newValue;
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError,
+                tristate: widget.indeterminate,
+              ),
+              OudsCheckbox(
+                value: isCheckedSecond,
+                onChanged: customizationState?.hasEnabled == true
+                    ? (bool? newValue) {
+                        setState(() {
+                          isCheckedSecond = newValue;
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError ? true : false,
+                tristate: widget.indeterminate,
+              ),
+            ],
           ),
-          OudsCheckbox(
-            value: isCheckedSecond,
-            onChanged: customizationState?.hasEnabled == true
-                ? (bool? newValue) {
-                    setState(() {
-                      isCheckedSecond = newValue;
-                    });
-                  }
-                : null,
-            isError: customizationState!.hasError ? true : false,
-            tristate: widget.indeterminate,
+        ),
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OudsCheckbox(
+                value: isCheckedFirst,
+                onChanged: customizationState?.hasEnabled == true
+                    ? (bool? newValue) {
+                        setState(() {
+                          isCheckedFirst = newValue;
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError,
+                tristate: widget.indeterminate,
+              ),
+              OudsCheckbox(
+                value: isCheckedSecond,
+                onChanged: customizationState?.hasEnabled == true
+                    ? (bool? newValue) {
+                        setState(() {
+                          isCheckedSecond = newValue;
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError ? true : false,
+                tristate: widget.indeterminate,
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -83,7 +83,7 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    ThemeController? themeController = Provider.of<ThemeController>(context, listen: false);
+    ThemeController? themeController = Provider.of<ThemeController>(context, listen: true);
     return DetailScreenDescription(
       widget: Column(
         children: [

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -127,7 +127,7 @@ class _CheckboxDemoState extends State<_CheckboxDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return CustomizableSection(
+    return Column(
       children: [
         ThemeBox(
           themeContract: themeController!.currentTheme,

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -12,22 +12,23 @@
 
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/checkbox/ouds_checkbox_item.dart';
-import 'package:ouds_core/components/ouds_colored_box.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_code_generator.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_customization.dart';
-import 'package:ouds_flutter_demo/ui/components/control_item/control_item_customization_utils.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_enum.dart';
 import 'package:ouds_flutter_demo/ui/theme/theme_controller.dart';
-import 'package:ouds_flutter_demo/ui/utilities/app_assets.dart';
 import 'package:ouds_flutter_demo/ui/utilities/code.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
+
+import '../../utilities/app_assets.dart';
+import '../control_item/control_item_customization_utils.dart';
 
 /// This screen displays a checkbox demo and allows customization of checkbox properties.
 class ControlItemDemoScreen extends StatefulWidget {
@@ -114,11 +115,110 @@ class _CheckboxItemDemoState extends State<_CheckboxItemDemo> {
   bool? isCheckedSecond = false;
 
   ControlItemCustomizationState? customizationState;
+  ThemeController? themeController;
 
   @override
   Widget build(BuildContext context) {
     customizationState = ControlItemCustomization.of(context);
-    return OudsColoredBox(
+    themeController = Provider.of<ThemeController>(context, listen: false);
+
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
+
+    return Column(children: [
+      ThemeBox(
+        themeContract: themeController!.currentTheme,
+        themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+        child: Column(
+          children: [
+            OudsCheckboxItem(
+              value: isCheckedFirst,
+              onChanged: customizationState!.hasEnabled
+                  ? (bool? newValue) {
+                      setState(() {
+                        isCheckedFirst = newValue;
+                      });
+                    }
+                  : null,
+              title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+              helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+              reversed: customizationState!.hasReversed ? true : false,
+              readOnly: customizationState!.hasReadOnly ? true : false,
+              icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+              isError: customizationState!.hasError ? true : false,
+              divider: customizationState!.hasDivider ? true : false,
+              tristate: widget.indeterminate,
+            ),
+            OudsCheckboxItem(
+              value: isCheckedSecond,
+              onChanged: customizationState!.hasEnabled
+                  ? (bool? newValue) {
+                      setState(() {
+                        isCheckedSecond = newValue;
+                      });
+                    }
+                  : null,
+              title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+              helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+              reversed: customizationState!.hasReversed ? true : false,
+              readOnly: customizationState!.hasReadOnly ? true : false,
+              icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+              isError: customizationState!.hasError ? true : false,
+              divider: customizationState!.hasDivider ? true : false,
+              tristate: widget.indeterminate,
+            ),
+          ],
+        ),
+      ),
+      ThemeBox(
+        themeContract: themeController!.currentTheme,
+        themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+        child: Column(
+          children: [
+            OudsCheckboxItem(
+              value: isCheckedFirst,
+              onChanged: customizationState!.hasEnabled
+                  ? (bool? newValue) {
+                      setState(() {
+                        isCheckedFirst = newValue;
+                      });
+                    }
+                  : null,
+              title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+              helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+              reversed: customizationState!.hasReversed ? true : false,
+              readOnly: customizationState!.hasReadOnly ? true : false,
+              icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+              isError: customizationState!.hasError ? true : false,
+              divider: customizationState!.hasDivider ? true : false,
+              tristate: widget.indeterminate,
+            ),
+            OudsCheckboxItem(
+              value: isCheckedSecond,
+              onChanged: customizationState!.hasEnabled
+                  ? (bool? newValue) {
+                      setState(() {
+                        isCheckedSecond = newValue;
+                      });
+                    }
+                  : null,
+              title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+              helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+              reversed: customizationState!.hasReversed ? true : false,
+              readOnly: customizationState!.hasReadOnly ? true : false,
+              icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+              isError: customizationState!.hasError ? true : false,
+              divider: customizationState!.hasDivider ? true : false,
+              tristate: widget.indeterminate,
+            ),
+          ],
+        ),
+      )
+    ]);
+
+    /*OudsColoredBox(
       color: OudsColoredBoxColor.statusNeutralMuted,
       child: Column(
         children: [
@@ -163,6 +263,7 @@ class _CheckboxItemDemoState extends State<_CheckboxItemDemo> {
         ],
       ),
     );
+       */
   }
 }
 

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -85,7 +85,7 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    final themeController = Provider.of<ThemeController>(context, listen: false);
+    final themeController = Provider.of<ThemeController>(context, listen: true);
     return DetailScreenDescription(
       widget: Column(
         children: [

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -127,7 +127,7 @@ class _CheckboxItemDemoState extends State<_CheckboxItemDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return Column(children: [
+    return CustomizableSection(children: [
       ThemeBox(
         themeContract: themeController!.currentTheme,
         themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
@@ -217,53 +217,6 @@ class _CheckboxItemDemoState extends State<_CheckboxItemDemo> {
         ),
       )
     ]);
-
-    /*OudsColoredBox(
-      color: OudsColoredBoxColor.statusNeutralMuted,
-      child: Column(
-        children: [
-          Center(
-            child: OudsCheckboxItem(
-              value: isCheckedFirst,
-              onChanged: customizationState!.hasEnabled
-                  ? (bool? newValue) {
-                      setState(() {
-                        isCheckedFirst = newValue;
-                      });
-                    }
-                  : null,
-              title: ControlItemCustomizationUtils.getLabelText(customizationState!),
-              helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
-              reversed: customizationState!.hasReversed ? true : false,
-              readOnly: customizationState!.hasReadOnly ? true : false,
-              icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
-              isError: customizationState!.hasError ? true : false,
-              divider: customizationState!.hasDivider ? true : false,
-              tristate: widget.indeterminate,
-            ),
-          ),
-          OudsCheckboxItem(
-            value: isCheckedSecond,
-            onChanged: customizationState!.hasEnabled
-                ? (bool? newValue) {
-                    setState(() {
-                      isCheckedSecond = newValue;
-                    });
-                  }
-                : null,
-            title: ControlItemCustomizationUtils.getLabelText(customizationState!),
-            helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
-            reversed: customizationState!.hasReversed ? true : false,
-            readOnly: customizationState!.hasReadOnly ? true : false,
-            icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
-            isError: customizationState!.hasError ? true : false,
-            divider: customizationState!.hasDivider ? true : false,
-            tristate: widget.indeterminate,
-          ),
-        ],
-      ),
-    );
-       */
   }
 }
 

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -55,7 +55,8 @@ class _ControlItemDemoScreenState extends State<ControlItemDemoScreen> {
     return ControlItemCustomization(
       child: Scaffold(
         key: _scaffoldKey,
-        appBar: widget.indeterminate ? MainAppBar(title: context.l10n.app_components_checkbox_indeterminateCheckboxItem_label) : MainAppBar(title: context.l10n.app_components_checkbox_checkboxItem_label),
+        appBar:
+            widget.indeterminate ? MainAppBar(title: context.l10n.app_components_checkbox_indeterminateCheckboxItem_label) : MainAppBar(title: context.l10n.app_components_checkbox_checkboxItem_label),
         body: SafeArea(
           child: ExcludeSemantics(
             excluding: !_isBottomSheetExpanded,
@@ -127,7 +128,7 @@ class _CheckboxItemDemoState extends State<_CheckboxItemDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return CustomizableSection(children: [
+    return Column(children: [
       ThemeBox(
         themeContract: themeController!.currentTheme,
         themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -16,8 +16,10 @@ import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_code_generator.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_customization.dart';
+import 'package:ouds_flutter_demo/ui/components/control_item/control_item_customization_utils.dart';
 import 'package:ouds_flutter_demo/ui/components/control_item/control_item_enum.dart';
 import 'package:ouds_flutter_demo/ui/theme/theme_controller.dart';
+import 'package:ouds_flutter_demo/ui/utilities/app_assets.dart';
 import 'package:ouds_flutter_demo/ui/utilities/code.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
@@ -26,9 +28,6 @@ import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
 import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
-
-import '../../utilities/app_assets.dart';
-import '../control_item/control_item_customization_utils.dart';
 
 /// This screen displays a checkbox demo and allows customization of checkbox properties.
 class ControlItemDemoScreen extends StatefulWidget {

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -12,11 +12,9 @@ import 'package:ouds_flutter_demo/ui/utilities/code.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_dropdown_menu.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
-
-import '../../utilities/customizable/customizable_section.dart' show CustomizableSection;
-import '../../utilities/theme_colored_box.dart';
 
 class DividerDemoScreen extends StatefulWidget {
   final bool vertical;
@@ -162,7 +160,7 @@ class _DividerDemoState extends State<_DividerDemo> {
             : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
       );
     } else {
-      return CustomizableSection(
+      return Column(
         children: [
           /// [themeMode] we test here theme of system and inverse theme mode if is not dark
           ThemeBox(

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -15,6 +15,7 @@ import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
 
+import '../../utilities/customizable/customizable_section.dart' show CustomizableSection;
 import '../../utilities/theme_colored_box.dart';
 
 class DividerDemoScreen extends StatefulWidget {
@@ -161,7 +162,7 @@ class _DividerDemoState extends State<_DividerDemo> {
             : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
       );
     } else {
-      return Column(
+      return CustomizableSection(
         children: [
           /// [themeMode] we test here theme of system and inverse theme mode if is not dark
           ThemeBox(

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -113,7 +113,7 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    ThemeController? themeController = Provider.of<ThemeController>(context, listen: false);
+    ThemeController? themeController = Provider.of<ThemeController>(context, listen: true);
     return DetailScreenDescription(
       widget: Column(
         children: [

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -15,6 +15,8 @@ import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
 
+import '../../utilities/theme_colored_box.dart';
+
 class DividerDemoScreen extends StatefulWidget {
   final bool vertical;
 
@@ -151,11 +153,33 @@ class _DividerDemoState extends State<_DividerDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return OudsColoredBox(
-      color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
-      child: widget.vertical
-          ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
-          : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
-    );
+    if (customizationState?.hasOnColoredBox == true) {
+      return OudsColoredBox(
+        color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
+        child: widget.vertical
+            ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
+            : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
+      );
+    } else {
+      return Column(
+        children: [
+          /// [themeMode] we test here theme of system and inverse theme mode if is not dark
+          ThemeBox(
+            themeContract: themeController!.currentTheme,
+            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+            child: widget.vertical
+                ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
+                : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
+          ),
+          ThemeBox(
+            themeContract: themeController!.currentTheme,
+            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+            child: widget.vertical
+                ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
+                : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
+          )
+        ],
+      );
+    }
   }
 }

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/divider/ouds_divider.dart';
-import 'package:ouds_core/components/ouds_colored_box.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
 import 'package:ouds_flutter_demo/ui/components/divider/divider_code_generator.dart';
@@ -152,33 +151,24 @@ class _DividerDemoState extends State<_DividerDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    if (customizationState?.hasOnColoredBox == true) {
-      return OudsColoredBox(
-        color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
-        child: widget.vertical
-            ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
-            : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
-      );
-    } else {
-      return Column(
-        children: [
-          /// [themeMode] we test here theme of system and inverse theme mode if is not dark
-          ThemeBox(
-            themeContract: themeController!.currentTheme,
-            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
-            child: widget.vertical
-                ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
-                : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
-          ),
-          ThemeBox(
-            themeContract: themeController!.currentTheme,
-            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
-            child: widget.vertical
-                ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
-                : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
-          )
-        ],
-      );
-    }
+    return Column(
+      children: [
+        /// [themeMode] we test here theme of system and inverse theme mode if is not dark
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+          child: widget.vertical
+              ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
+              : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
+        ),
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+          child: widget.vertical
+              ? OudsDivider.vertical(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor))
+              : OudsDivider.horizontal(color: DividerCustomizationUtils.getOudsDividerColor(customizationState?.selectedColor)),
+        )
+      ],
+    );
   }
 }

--- a/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
@@ -12,7 +12,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:ouds_core/components/ouds_colored_box.dart';
 import 'package:ouds_core/components/radio_button/ouds_radio_button.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
@@ -25,6 +24,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
 import 'package:provider/provider.dart';
+
+import '../../utilities/theme_colored_box.dart';
 
 enum RadioOption { first, second }
 
@@ -124,10 +125,51 @@ class _RadioButtonDemoState extends State<_RadioButtonDemo> {
   @override
   Widget build(BuildContext context) {
     customizationState = RadioButtonCustomization.of(context);
+    themeController = Provider.of<ThemeController>(context, listen: false);
+
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
+
     return CustomizableSection(
       children: [
-        OudsColoredBox(
-          color: OudsColoredBoxColor.statusNeutralMuted,
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OudsRadioButton<RadioOption>(
+                value: RadioOption.first,
+                groupValue: widget.selectedOption,
+                onChanged: customizationState!.hasEnabled
+                    ? (RadioOption? value) {
+                        setState(() {
+                          widget.updateGlobalValue(value!);
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError,
+              ),
+              OudsRadioButton<RadioOption>(
+                value: RadioOption.second,
+                groupValue: widget.selectedOption,
+                onChanged: customizationState!.hasEnabled
+                    ? (RadioOption? value) {
+                        setState(() {
+                          widget.updateGlobalValue(value!);
+                        });
+                      }
+                    : null,
+                isError: customizationState!.hasError,
+              ),
+            ],
+          ),
+        ),
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [

--- a/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
@@ -89,7 +89,7 @@ class _BodyState extends State<_Body> {
 
   @override
   Widget build(BuildContext context) {
-    ThemeController? themeController = Provider.of<ThemeController>(context, listen: false);
+    ThemeController? themeController = Provider.of<ThemeController>(context, listen: true);
     return DetailScreenDescription(
       description: context.l10n.app_components_radioButton_description_text,
       widget: Column(

--- a/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
@@ -23,9 +23,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
-
-import '../../utilities/theme_colored_box.dart';
 
 enum RadioOption { first, second }
 

--- a/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
@@ -132,7 +132,7 @@ class _RadioButtonDemoState extends State<_RadioButtonDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
-    return CustomizableSection(
+    return Column(
       children: [
         ThemeBox(
           themeContract: themeController!.currentTheme,

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -28,9 +28,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
+import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:provider/provider.dart';
-
-import '../../utilities/theme_colored_box.dart';
 
 class RadioButtonItemDemoScreen extends StatefulWidget {
   final bool indeterminate;

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -86,7 +86,7 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    final themeController = Provider.of<ThemeController>(context, listen: false);
+    final themeController = Provider.of<ThemeController>(context, listen: true);
     return DetailScreenDescription(
       widget: Column(
         children: [

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -12,7 +12,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:ouds_core/components/ouds_colored_box.dart';
 import 'package:ouds_core/components/radio_button/ouds_radio_button_item.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
 import 'package:ouds_flutter_demo/main_app_bar.dart';
@@ -30,6 +29,8 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfie
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart';
 import 'package:provider/provider.dart';
+
+import '../../utilities/theme_colored_box.dart';
 
 class RadioButtonItemDemoScreen extends StatefulWidget {
   final bool indeterminate;
@@ -90,7 +91,7 @@ class _BodyState extends State<_Body> {
       widget: Column(
         children: [
           _RadioButtonItemDemo(indeterminate: widget.indeterminate),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
+          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedTall),
           Code(
             code: ControlItemCodeGenerator.updateCode(context, widget.indeterminate, ControlItemType.radioButton),
           ),
@@ -113,17 +114,72 @@ class _RadioButtonItemDemo extends StatefulWidget {
 class _RadioButtonItemDemoState extends State<_RadioButtonItemDemo> {
   RadioOption _selectedOption = RadioOption.first;
 
+  ThemeController? themeController;
   ControlItemCustomizationState? customizationState;
 
   @override
   Widget build(BuildContext context) {
     customizationState = ControlItemCustomization.of(context);
+    themeController = Provider.of<ThemeController>(context, listen: false);
+
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
     return CustomizableSection(
       children: [
-        OudsColoredBox(
-          color: OudsColoredBoxColor.statusNeutralMuted,
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              OudsRadioButtonItem<RadioOption>(
+                value: RadioOption.first,
+                groupValue: _selectedOption,
+                onChanged: customizationState!.hasEnabled
+                    ? (RadioOption? value) {
+                        setState(() {
+                          _selectedOption = value!;
+                        });
+                      }
+                    : null,
+                title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+                additionalLabel: ControlItemCustomizationUtils.getAdditionalLabelText(customizationState!),
+                helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+                outlined: customizationState!.hasOutlined ? true : false,
+                reversed: customizationState!.hasReversed ? true : false,
+                readOnly: customizationState!.hasReadOnly ? true : false,
+                icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+                isError: customizationState!.hasError ? true : false,
+                divider: customizationState!.hasDivider ? true : false,
+              ),
+              OudsRadioButtonItem<RadioOption>(
+                value: RadioOption.second,
+                groupValue: _selectedOption,
+                onChanged: customizationState!.hasEnabled
+                    ? (RadioOption? value) {
+                        setState(() {
+                          _selectedOption = value!;
+                        });
+                      }
+                    : null,
+                title: ControlItemCustomizationUtils.getLabelText(customizationState!),
+                additionalLabel: ControlItemCustomizationUtils.getAdditionalLabelText(customizationState!),
+                helperTitle: ControlItemCustomizationUtils.getHelperLabelText(customizationState!),
+                outlined: customizationState!.hasOutlined ? true : false,
+                reversed: customizationState!.hasReversed ? true : false,
+                readOnly: customizationState!.hasReadOnly ? true : false,
+                icon: customizationState!.hasIcon ? AppAssets.icons.icHeart : null,
+                isError: customizationState!.hasError ? true : false,
+                divider: customizationState!.hasDivider ? true : false,
+              ),
+            ],
+          ),
+        ),
+        ThemeBox(
+          themeContract: themeController!.currentTheme,
+          themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+          child: Column(
             children: [
               OudsRadioButtonItem<RadioOption>(
                 value: RadioOption.first,

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -126,7 +126,7 @@ class _RadioButtonItemDemoState extends State<_RadioButtonItemDemo> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
-    return CustomizableSection(
+    return Column(
       children: [
         ThemeBox(
           themeContract: themeController!.currentTheme,

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -90,7 +90,7 @@ class _BodyState extends State<_Body> {
       widget: Column(
         children: [
           _RadioButtonItemDemo(indeterminate: widget.indeterminate),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedTall),
+          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
           Code(
             code: ControlItemCodeGenerator.updateCode(context, widget.indeterminate, ControlItemType.radioButton),
           ),

--- a/app/lib/ui/theme/theme_controller.dart
+++ b/app/lib/ui/theme/theme_controller.dart
@@ -103,6 +103,15 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
+  bool get isInverseDarkTheme {
+    if (themeMode == ThemeMode.system) {
+      final Brightness brightness = WidgetsBinding.instance.platformDispatcher.platformBrightness;
+      return brightness == Brightness.light;
+    } else {
+      return themeMode == ThemeMode.light;
+    }
+  }
+
   /// Returns the appropriate theme instance based on the current theme type
   OudsThemeContract _getThemeForCurrentType(Type currentType) {
     if (currentType == OrangeTheme) {

--- a/app/lib/ui/utilities/theme_colored_box.dart
+++ b/app/lib/ui/utilities/theme_colored_box.dart
@@ -1,0 +1,116 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+import 'package:flutter/material.dart';
+import 'package:ouds_theme_contract/ouds_theme.dart';
+import 'package:ouds_theme_contract/ouds_theme_contract.dart';
+
+/// A widget that applies a specific theme to its child using [OudsTheme].
+///
+/// This widget allows setting a theme mode (`ThemeMode`) and a theme contract
+/// (`OudsThemeContract`). It wraps its child inside a background colored by a [ColoredBox].
+class ThemeBox extends StatelessWidget {
+  /// The widget to display inside the [ThemeBox].
+  final Widget child;
+
+  /// The theme mode to apply (light, dark, or system).
+  final ThemeMode themeMode;
+
+  /// The theme contract defining the theme's design tokens and styles.
+  final OudsThemeContract themeContract;
+
+  /// Constructor for [ThemeBox].
+  ///
+  /// Requires [child], [themeMode], and [themeContract].
+  const ThemeBox({
+    required this.child,
+    required this.themeMode,
+    required this.themeContract,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return OudsTheme(
+      themeContract: themeContract,
+      themeMode: themeMode,
+      onColoredSurface: false,
+      child: Builder(
+        builder: (context) {
+          return ColoredBox(
+            color: ColoredBoxColor.backgroundPrimary,
+            child: Column(
+              children: [
+                child,
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A demo colored box widget used to showcase `DARK` and `LIGHT` modes.
+/// It displays a background with centered content and a minimum height.
+class ColoredBox extends StatelessWidget {
+  /// The widget to display at the center of the box.
+  final Widget child;
+
+  /// The background color of the box, optional.
+  final ColoredBoxColor? color;
+
+  /// Constructor for [ColoredBox].
+  ///
+  /// Requires [child], [color] is optional.
+  const ColoredBox({
+    required this.child,
+    this.color,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: BoxConstraints(
+        minHeight: 80,
+      ),
+      width: double.infinity,
+      color: color?.getValue(context),
+      child: Padding(
+        padding: EdgeInsetsDirectional.symmetric(
+          vertical: OudsTheme.of(context).spaceScheme(context).fixedMedium,
+          horizontal: OudsTheme.of(context).spaceScheme(context).fixedNone,
+        ),
+        child: Center(
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+/// Enumeration representing the possible background colors of a [ColoredBox].
+enum ColoredBoxColor {
+  /// Primary background color.
+  backgroundPrimary;
+
+  /// Retrieves the color value associated with this enum in the current context.
+  Color getValue(BuildContext context) {
+    final theme = OudsTheme.of(context);
+
+    switch (this) {
+      case ColoredBoxColor.backgroundPrimary:
+        return theme.colorScheme(context).bgPrimary;
+    }
+  }
+}

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -157,7 +157,7 @@ class _OudsButtonState extends State<OudsButton> {
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadius),
           child: OutlinedButton(
-            onPressed: () => _handlePressed(widget.onPressed),
+            onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
             child: Stack(
               alignment: Alignment.center,
@@ -233,7 +233,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: IconButton(
               style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
-              onPressed: () => _handlePressed(widget.onPressed),
+              onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
               icon: widget.icon!,
             ),
           ),
@@ -267,7 +267,7 @@ class _OudsButtonState extends State<OudsButton> {
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadius),
           child: OutlinedButton(
             style: ButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
-            onPressed: () => _handlePressed(widget.onPressed),
+            onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             child: Text(
               widget.label ?? "",
               textAlign: TextAlign.center,

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -7,9 +7,8 @@ import 'package:ouds_core/components/control/internal/modifier/ouds_control_back
 import 'package:ouds_core/components/control/internal/modifier/ouds_control_border_modifier.dart';
 import 'package:ouds_core/components/control/internal/modifier/ouds_control_text_modifier.dart';
 import 'package:ouds_core/components/control/internal/ouds_control_state.dart';
+import 'package:ouds_core/components/divider/ouds_divider.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
-
-import '../divider/ouds_divider.dart';
 
 /// Refactor of controls for [Checkbox], [Switch], and [RadioButton].
 /// This implementation provides a customizable control item with properties such as text, icon, and interaction states.

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -156,6 +156,7 @@ class OudsControlItemState extends State<OudsControlItem> {
                 ),
                 if (widget.divider)
                   Divider(
+                    color: OudsTheme.of(context).componentsTokens(context).controlItem.colorBgHover,
                     height: 0,
                     thickness: OudsTheme.of(context).borderTokens.widthDefault,
                   ),

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -156,7 +156,7 @@ class OudsControlItemState extends State<OudsControlItem> {
                 ),
                 if (widget.divider)
                   Divider(
-                    color: OudsTheme.of(context).componentsTokens(context).controlItem.colorBgHover,
+                    color: OudsTheme.of(context).colorScheme(context).borderDefault,
                     height: 0,
                     thickness: OudsTheme.of(context).borderTokens.widthDefault,
                   ),

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -9,6 +9,8 @@ import 'package:ouds_core/components/control/internal/modifier/ouds_control_text
 import 'package:ouds_core/components/control/internal/ouds_control_state.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
+import '../divider/ouds_divider.dart';
+
 /// Refactor of controls for [Checkbox], [Switch], and [RadioButton].
 /// This implementation provides a customizable control item with properties such as text, icon, and interaction states.
 /// It manages its own interaction state and can respond to tap events if not in read-only mode.
@@ -155,11 +157,14 @@ class OudsControlItemState extends State<OudsControlItem> {
                   ),
                 ),
                 if (widget.divider)
-                  Divider(
+                  OudsDivider.horizontal(
+                    color: OudsDividerColor.defaultColor,
+                  )
+                /*Divider(
                     color: OudsTheme.of(context).colorScheme(context).borderDefault,
                     height: 0,
                     thickness: OudsTheme.of(context).borderTokens.widthDefault,
-                  ),
+                  ),*/
               ],
             ),
             if (widget.outlined || (widget.selected && interactionState.isPressed))

--- a/ouds_core/lib/components/divider/ouds_divider.dart
+++ b/ouds_core/lib/components/divider/ouds_divider.dart
@@ -94,7 +94,7 @@ class OudsDivider extends StatelessWidget {
       margin: margin,
     );
 
-    return Padding(padding: EdgeInsetsDirectional.all(OudsTheme.of(context).spaceScheme(context).fixedMedium), child: divider);
+    return Padding(padding: EdgeInsetsDirectional.all(OudsTheme.of(context).spaceScheme(context).fixedNone), child: divider);
   }
 }
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#223 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
