### PR TITLE
feat: border tokens

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -30,6 +30,8 @@ ouds-flutter/app/assets/il_tokens_opacity.svg
 ouds-flutter/app/assets/il_tokens_opacity_dark.svg
 ouds-flutter/app/assets/il_tokens_typography.svg
 ouds-flutter/app/assets/il_tokens_typography_dark.svg
+ouds-flutter/app/assets/il_tokens_border.svg
+ouds-flutter/app/assets/il_tokens_border_dark.svg
 ouds-flutter/app/assets/il_components_divider.svg
 ouds-flutter/app/assets/il_components_divider_dark.svg
 ouds-flutter/app/assets/il_components_checkbox.svg

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.2.0...0.3.0) - 2025-06-10
 
 ### Added
+- [DemoApp][Library] Tokens: screen Border ([#248](https://github.com/Orange-OpenSource/ouds-flutter/issues/248))
 - [Library] `Chip` component (tokens library v0.11.0) ([##215](https://github.com/Orange-OpenSource/ouds-flutter/issues/#215)
 - [DemoApp][Library] Tokens: screen typography ([#138](https://github.com/Orange-OpenSource/ouds-flutter/issues/138))
 - [DemoApp][Library] Create component - `Divider` ([#57](https://github.com/Orange-OpenSource/ouds-flutter/issues/57))

--- a/app/assets/il_tokens_border.svg
+++ b/app/assets/il_tokens_border.svg
@@ -1,0 +1,9 @@
+<svg width="360" height="186" viewBox="0 0 360 186" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="360" height="186" fill="black" fill-opacity="0.04"/>
+<mask id="mask0_2124_20154" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="140" y="53" width="80" height="80">
+<rect x="140" y="53" width="80" height="80" fill="white"/>
+</mask>
+<g mask="url(#mask0_2124_20154)">
+<path d="M150 123V63H210V69.6667H156.667V123H150ZM163.333 123V116.333H170V123H163.333ZM176.667 123V116.333H183.333V123H176.667ZM190 123V116.333H196.667V123H190ZM203.333 123V116.333H210V123H203.333ZM203.333 109.667V103H210V109.667H203.333ZM203.333 96.3333V89.6667H210V96.3333H203.333ZM203.333 83V76.3333H210V83H203.333Z" fill="black"/>
+</g>
+</svg>

--- a/app/assets/il_tokens_border.svg
+++ b/app/assets/il_tokens_border.svg
@@ -1,3 +1,16 @@
+<!--
+  - // Software Name: OUDS Flutter
+  - // SPDX-FileCopyrightText: Copyright (c) Orange SA
+  - // SPDX-License-Identifier: MIT
+  - //
+  - // This software is distributed under the MIT license,
+  - // the text of which is available at https://opensource.org/license/MIT/
+  - // or see the "LICENSE" file for more details.
+  - //
+  - // Software description: Flutter library of reusable graphical components
+  - //
+  -->
+
 <svg width="360" height="186" viewBox="0 0 360 186" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="360" height="186" fill="black" fill-opacity="0.04"/>
 <mask id="mask0_2124_20154" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="140" y="53" width="80" height="80">

--- a/app/assets/il_tokens_border_dark.svg
+++ b/app/assets/il_tokens_border_dark.svg
@@ -1,0 +1,9 @@
+<svg width="328" height="184" viewBox="0 0 328 184" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="328" height="184" fill="white" fill-opacity="0.08"/>
+<mask id="mask0_4495_12874" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="124" y="52" width="80" height="80">
+<rect x="124" y="52" width="80" height="80" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_4495_12874)">
+<path d="M134 122V62H194V68.6667H140.667V122H134ZM147.333 122V115.333H154V122H147.333ZM160.667 122V115.333H167.333V122H160.667ZM174 122V115.333H180.667V122H174ZM187.333 122V115.333H194V122H187.333ZM187.333 108.667V102H194V108.667H187.333ZM187.333 95.3333V88.6667H194V95.3333H187.333ZM187.333 82V75.3333H194V82H187.333Z" fill="#EEEEEE"/>
+</g>
+</svg>

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
@@ -344,6 +344,36 @@ abstract class AppLocalizations {
   /// **'Typography is our system of fonts and text styles. They enhance communication and reinforce the brand style.'**
   String get app_tokens_typography_description_text;
 
+  /// No description provided for @app_tokens_border_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Border'**
+  String get app_tokens_border_label;
+
+  /// No description provided for @app_tokens_border_description_text.
+  ///
+  /// In en, this message translates to:
+  /// **'Borders are used for the stroke colours on components and also for the colours of divider lines for components like tables.'**
+  String get app_tokens_border_description_text;
+
+  /// No description provided for @app_tokens_border_width_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Width'**
+  String get app_tokens_border_width_label;
+
+  /// No description provided for @app_tokens_border_radius_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Radius'**
+  String get app_tokens_border_radius_label;
+
+  /// No description provided for @app_tokens_border_style_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Style'**
+  String get app_tokens_border_style_label;
+
   /// No description provided for @app_components_common_color_label.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
@@ -137,6 +137,22 @@ class AppLocalizationsAr extends AppLocalizations {
       'الطباعة هي نظامنا للخطوط وأنماط النصوص. فهي تُحسّن التواصل وتُعزز أسلوب علامتنا التجارية.';
 
   @override
+  String get app_tokens_border_label => 'الحدود';
+
+  @override
+  String get app_tokens_border_description_text =>
+      'الحدود تستخدم لألوان الإطار على المكونات وكذلك لألوان خطوط الفواصل للمكونات مثل الجداول.';
+
+  @override
+  String get app_tokens_border_width_label => 'العرض';
+
+  @override
+  String get app_tokens_border_radius_label => 'نصف القطر';
+
+  @override
+  String get app_tokens_border_style_label => 'النمط';
+
+  @override
   String get app_components_common_color_label => 'اللون';
 
   @override

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
@@ -137,6 +137,22 @@ class AppLocalizationsEn extends AppLocalizations {
       'Typography is our system of fonts and text styles. They enhance communication and reinforce the brand style.';
 
   @override
+  String get app_tokens_border_label => 'Border';
+
+  @override
+  String get app_tokens_border_description_text =>
+      'Borders are used for the stroke colours on components and also for the colours of divider lines for components like tables.';
+
+  @override
+  String get app_tokens_border_width_label => 'Width';
+
+  @override
+  String get app_tokens_border_radius_label => 'Radius';
+
+  @override
+  String get app_tokens_border_style_label => 'Style';
+
+  @override
   String get app_components_common_color_label => 'Color';
 
   @override

--- a/app/lib/l10n/ouds_flutter_ar.arb
+++ b/app/lib/l10n/ouds_flutter_ar.arb
@@ -47,6 +47,13 @@
   "app_tokens_typography_label": "الطباعة",
   "app_tokens_typography_description_text": "الطباعة هي نظامنا للخطوط وأنماط النصوص. فهي تُحسّن التواصل وتُعزز أسلوب علامتنا التجارية.",
 
+ "@_token_border": {},
+  "app_tokens_border_label": "الحدود",
+  "app_tokens_border_description_text": "الحدود تستخدم لألوان الإطار على المكونات وكذلك لألوان خطوط الفواصل للمكونات مثل الجداول.",
+  "app_tokens_border_width_label":"العرض",
+  "app_tokens_border_radius_label": "نصف القطر",
+  "app_tokens_border_style_label":"النمط",
+
   "@_components": {},
   "app_components_common_color_label": "اللون",
   "app_components_common_error_label": "خطأ",

--- a/app/lib/l10n/ouds_flutter_en.arb
+++ b/app/lib/l10n/ouds_flutter_en.arb
@@ -87,6 +87,13 @@
   "app_tokens_typography_label": "Typography",
   "app_tokens_typography_description_text": "Typography is our system of fonts and text styles. They enhance communication and reinforce the brand style.",
 
+ "@_token_border": {},
+  "app_tokens_border_label": "Border",
+  "app_tokens_border_description_text": "Borders are used for the stroke colours on components and also for the colours of divider lines for components like tables.",
+  "app_tokens_border_width_label":"Width",
+  "app_tokens_border_radius_label": "Radius",
+  "app_tokens_border_style_label":"Style",
+
   "@_components": {},
   "app_components_common_color_label": "Color",
   "app_components_common_error_label": "Error",

--- a/app/lib/ui/tokens/border/border_screen.dart
+++ b/app/lib/ui/tokens/border/border_screen.dart
@@ -1,0 +1,240 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
+import 'package:ouds_flutter_demo/main_app_bar.dart';
+import 'package:ouds_flutter_demo/ui/theme/theme_controller.dart';
+import 'package:ouds_flutter_demo/ui/utilities/adaptive_image_helper.dart';
+import 'package:ouds_flutter_demo/ui/utilities/code.dart';
+import 'package:ouds_theme_contract/ouds_theme_contract.dart';
+import 'package:provider/provider.dart';
+
+class BorderScreen extends StatelessWidget {
+  final String illustration;
+
+  const BorderScreen({super.key, required this.illustration});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeController = Provider.of<ThemeController>(context, listen: false);
+    final currentTheme = themeController.currentTheme;
+    final List<BorderTokenItem> borderItems = _getBorderTokenItems(currentTheme);
+    final Map<String, List<BorderTokenItem>> tokenGroups = BorderTokenGrouper(borderItems).groupBySection();
+
+    return Scaffold(
+      appBar: MainAppBar(title: context.l10n.app_tokens_border_label),
+      body: SafeArea(
+        child: ListView(
+          children: [
+            SvgPicture.asset(
+              AdaptiveImageHelper.getImage(context, illustration),
+              fit: BoxFit.fitWidth,
+            ),
+            Padding(
+              padding: EdgeInsetsDirectional.all(currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge),
+              child: Column(
+                children: [
+                  Text(
+                    context.l10n.app_tokens_elevation_description_text,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+            Code(
+              titleText: context.l10n.app_tokens_viewCodeExample_label,
+              code: 'OudsTheme.of(context).borderTokens.widthDefault',
+            ),
+            ListView(
+              shrinkWrap: true,
+              physics: NeverScrollableScrollPhysics(),
+              padding: EdgeInsetsDirectional.only(
+                top: currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge,
+                bottom: currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge,
+              ),
+              children: [
+                for (var entry in tokenGroups.entries) ...[
+                  Padding(
+                    padding: EdgeInsetsDirectional.symmetric(
+                      vertical: currentTheme.spaceScheme(context).rowGapLarge,
+                      horizontal: currentTheme.spaceScheme(context).rowGapLarge,
+                    ),
+                    child: Semantics(
+                      header: true,
+                      child: Text(
+                        entry.key,
+                        style: currentTheme.typographyTokens.typeHeadingSmall(context).copyWith(color: currentTheme.colorScheme(context).contentDefault),
+                      ),
+                    ),
+                  ),
+                  ...entry.value.map(
+                    (item) => Padding(
+                      padding: EdgeInsetsDirectional.symmetric(
+                        horizontal: currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge,
+                      ),
+                      child: BorderWidget(borderTokenItem: item),
+                    ),
+                  ),
+                ],
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class BorderWidget extends StatelessWidget {
+  const BorderWidget({super.key, required this.borderTokenItem});
+
+  final BorderTokenItem borderTokenItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final themeController = Provider.of<ThemeController>(context, listen: false);
+    final currentTheme = themeController.currentTheme;
+
+    return Padding(
+      padding: EdgeInsetsDirectional.symmetric(
+        vertical: currentTheme.spaceScheme(context).rowGapSmall,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: currentTheme.colorScheme(context).bgSecondary,
+              border: Border.all(
+                color: currentTheme.colorScheme(context).borderFocus,
+                width: borderTokenItem.sectionName == BorderSection.Width ? borderTokenItem.value as double : 1.0,
+
+                /// ToDo: ----------- Modify this section with the logic of DashedBorderPainter if is OK ------------
+                style: borderTokenItem.sectionName == BorderSection.Style
+                    ? borderTokenItem.value == "solid"
+                        ? BorderStyle.solid
+                        : BorderStyle.none
+                    : BorderStyle.solid,
+
+                /// ToDo: ---------------------------- End Of the Modification ---------------------------------------
+              ),
+              borderRadius: BorderRadius.circular(
+                borderTokenItem.sectionName == BorderSection.Radius ? borderTokenItem.value as double : 1.0, // utilise le radius si défini
+              ),
+            ),
+          ),
+          SizedBox(width: currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  borderTokenItem.tokenName,
+                  style: currentTheme.typographyTokens.typeBodyStrongLarge(context).copyWith(
+                        color: currentTheme.colorScheme(context).contentDefault,
+                      ),
+                ),
+                SizedBox(height: currentTheme.spaceScheme(context).rowGapNone),
+                Text(
+                  borderTokenItem.value.toString(),
+                  style: currentTheme.typographyTokens.typeBodyDefaultMedium(context).copyWith(
+                        color: currentTheme.colorScheme(context).contentMuted,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Enum representing different sections of border properties.
+enum BorderSection {
+  Width,
+  Radius,
+  Style,
+}
+
+extension BorderSectionExtension on BorderSection {
+  String stringValue(BuildContext context) {
+    switch (this) {
+      case BorderSection.Width:
+        return context.l10n.app_tokens_border_width_label;
+      case BorderSection.Radius:
+        return context.l10n.app_tokens_border_radius_label;
+      case BorderSection.Style:
+        return context.l10n.app_tokens_border_style_label;
+    }
+  }
+}
+
+/// Represents a border property with a section (like Width, Radius, or Style), a name, and a value.
+class BorderTokenItem {
+  const BorderTokenItem({
+    required this.sectionName,
+    required this.tokenName,
+    required this.value,
+  });
+
+  final BorderSection sectionName;
+  final String tokenName;
+  final dynamic value;
+}
+
+/// Groups a list of border items by their section names.
+class BorderTokenGrouper {
+  final List<BorderTokenItem> items;
+
+  BorderTokenGrouper(this.items);
+
+  Map<String, List<BorderTokenItem>> groupBySection() {
+    final Map<String, List<BorderTokenItem>> grouped = {};
+
+    for (var item in items) {
+      grouped.putIfAbsent(item.sectionName.name, () => []).add(item);
+    }
+
+    return grouped;
+  }
+}
+
+/// Creates a list of border items based on the current theme, including widths, radii, and styles.
+List<BorderTokenItem> _getBorderTokenItems(OudsThemeContract currentTheme) {
+  return [
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthNone', value: currentTheme.borderTokens.widthNone),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthDefault', value: currentTheme.borderTokens.widthDefault),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThin', value: currentTheme.borderTokens.widthThin),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthMedium', value: currentTheme.borderTokens.widthMedium),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThick', value: currentTheme.borderTokens.widthThick),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThicker', value: currentTheme.borderTokens.widthThicker),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthFocus', value: currentTheme.borderTokens.widthFocus),
+    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthFocusInset', value: currentTheme.borderTokens.widthFocusInset),
+
+    // Section Radius
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusNone', value: currentTheme.borderTokens.radiusNone),
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusDefault', value: currentTheme.borderTokens.radiusDefault),
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusSmall', value: currentTheme.borderTokens.radiusSmall),
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusMedium', value: currentTheme.borderTokens.radiusMedium),
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusLarge', value: currentTheme.borderTokens.radiusLarge),
+    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusPill', value: currentTheme.borderTokens.radiusPill),
+    // Section Style
+    BorderTokenItem(sectionName: BorderSection.Style, tokenName: 'borderStyleDefault', value: currentTheme.borderTokens.styleDefault),
+    BorderTokenItem(sectionName: BorderSection.Style, tokenName: 'borderStyleDrag', value: currentTheme.borderTokens.styleDrag),
+  ];
+}

--- a/app/lib/ui/tokens/border/border_screen.dart
+++ b/app/lib/ui/tokens/border/border_screen.dart
@@ -11,6 +11,7 @@
  * //
  */
 
+import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
@@ -107,6 +108,23 @@ class BorderWidget extends StatelessWidget {
     final themeController = Provider.of<ThemeController>(context, listen: false);
     final currentTheme = themeController.currentTheme;
 
+    final color = currentTheme.colorScheme(context).borderFocus;
+    final bgColor = currentTheme.colorScheme(context).bgSecondary;
+    final width = borderTokenItem.sectionName == BorderSection.width ? borderTokenItem.value as double : 1.0;
+    final radius = borderTokenItem.sectionName == BorderSection.radius ? borderTokenItem.value as double : 1.0;
+    final isDashed = borderTokenItem.sectionName == BorderSection.style && borderTokenItem.value == "dashed";
+
+    final borderRadius = BorderRadius.circular(radius);
+
+    final content = Container(
+      width: 61,
+      height: 61,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: borderRadius,
+      ),
+    );
+
     return Padding(
       padding: EdgeInsetsDirectional.symmetric(
         vertical: currentTheme.spaceScheme(context).rowGapSmall,
@@ -114,29 +132,28 @@ class BorderWidget extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 64,
-            height: 64,
-            decoration: BoxDecoration(
-              color: currentTheme.colorScheme(context).bgSecondary,
-              border: Border.all(
-                color: currentTheme.colorScheme(context).borderFocus,
-                width: borderTokenItem.sectionName == BorderSection.Width ? borderTokenItem.value as double : 1.0,
-
-                /// ToDo: ----------- Modify this section with the logic of DashedBorderPainter if is OK ------------
-                style: borderTokenItem.sectionName == BorderSection.Style
-                    ? borderTokenItem.value == "solid"
-                        ? BorderStyle.solid
-                        : BorderStyle.none
-                    : BorderStyle.solid,
-
-                /// ToDo: ---------------------------- End Of the Modification ---------------------------------------
-              ),
-              borderRadius: BorderRadius.circular(
-                borderTokenItem.sectionName == BorderSection.Radius ? borderTokenItem.value as double : 1.0, // utilise le radius si défini
-              ),
-            ),
-          ),
+          isDashed
+              ? DottedBorder(
+                  color: color,
+                  strokeWidth: width,
+                  dashPattern: [2, 2],
+                  borderType: BorderType.RRect,
+                  radius: Radius.circular(radius),
+                  child: content,
+                )
+              : Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: bgColor,
+                    borderRadius: borderRadius,
+                    border: Border.all(
+                      color: color,
+                      width: width,
+                      style: borderTokenItem.sectionName == BorderSection.style && borderTokenItem.value == "solid" ? BorderStyle.solid : BorderStyle.solid,
+                    ),
+                  ),
+                ),
           SizedBox(width: currentTheme.spaceScheme(context).paddingInlineTwoExtraLarge),
           Expanded(
             child: Column(
@@ -166,19 +183,19 @@ class BorderWidget extends StatelessWidget {
 
 /// Enum representing different sections of border properties.
 enum BorderSection {
-  Width,
-  Radius,
-  Style,
+  width,
+  radius,
+  style,
 }
 
 extension BorderSectionExtension on BorderSection {
   String stringValue(BuildContext context) {
     switch (this) {
-      case BorderSection.Width:
+      case BorderSection.width:
         return context.l10n.app_tokens_border_width_label;
-      case BorderSection.Radius:
+      case BorderSection.radius:
         return context.l10n.app_tokens_border_radius_label;
-      case BorderSection.Style:
+      case BorderSection.style:
         return context.l10n.app_tokens_border_style_label;
     }
   }
@@ -217,24 +234,24 @@ class BorderTokenGrouper {
 /// Creates a list of border items based on the current theme, including widths, radii, and styles.
 List<BorderTokenItem> _getBorderTokenItems(OudsThemeContract currentTheme) {
   return [
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthNone', value: currentTheme.borderTokens.widthNone),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthDefault', value: currentTheme.borderTokens.widthDefault),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThin', value: currentTheme.borderTokens.widthThin),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthMedium', value: currentTheme.borderTokens.widthMedium),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThick', value: currentTheme.borderTokens.widthThick),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthThicker', value: currentTheme.borderTokens.widthThicker),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthFocus', value: currentTheme.borderTokens.widthFocus),
-    BorderTokenItem(sectionName: BorderSection.Width, tokenName: 'borderWidthFocusInset', value: currentTheme.borderTokens.widthFocusInset),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthNone', value: currentTheme.borderTokens.widthNone),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthDefault', value: currentTheme.borderTokens.widthDefault),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthThin', value: currentTheme.borderTokens.widthThin),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthMedium', value: currentTheme.borderTokens.widthMedium),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthThick', value: currentTheme.borderTokens.widthThick),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthThicker', value: currentTheme.borderTokens.widthThicker),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthFocus', value: currentTheme.borderTokens.widthFocus),
+    BorderTokenItem(sectionName: BorderSection.width, tokenName: 'borderWidthFocusInset', value: currentTheme.borderTokens.widthFocusInset),
 
     // Section Radius
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusNone', value: currentTheme.borderTokens.radiusNone),
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusDefault', value: currentTheme.borderTokens.radiusDefault),
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusSmall', value: currentTheme.borderTokens.radiusSmall),
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusMedium', value: currentTheme.borderTokens.radiusMedium),
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusLarge', value: currentTheme.borderTokens.radiusLarge),
-    BorderTokenItem(sectionName: BorderSection.Radius, tokenName: 'borderRadiusPill', value: currentTheme.borderTokens.radiusPill),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusNone', value: currentTheme.borderTokens.radiusNone),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusDefault', value: currentTheme.borderTokens.radiusDefault),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusSmall', value: currentTheme.borderTokens.radiusSmall),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusMedium', value: currentTheme.borderTokens.radiusMedium),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusLarge', value: currentTheme.borderTokens.radiusLarge),
+    BorderTokenItem(sectionName: BorderSection.radius, tokenName: 'borderRadiusPill', value: currentTheme.borderTokens.radiusPill),
     // Section Style
-    BorderTokenItem(sectionName: BorderSection.Style, tokenName: 'borderStyleDefault', value: currentTheme.borderTokens.styleDefault),
-    BorderTokenItem(sectionName: BorderSection.Style, tokenName: 'borderStyleDrag', value: currentTheme.borderTokens.styleDrag),
+    BorderTokenItem(sectionName: BorderSection.style, tokenName: 'borderStyleDefault', value: currentTheme.borderTokens.styleDefault),
+    BorderTokenItem(sectionName: BorderSection.style, tokenName: 'borderStyleDrag', value: currentTheme.borderTokens.styleDrag),
   ];
 }

--- a/app/lib/ui/tokens/border/border_screen.dart
+++ b/app/lib/ui/tokens/border/border_screen.dart
@@ -113,6 +113,7 @@ class BorderWidget extends StatelessWidget {
     final width = borderTokenItem.sectionName == BorderSection.width ? borderTokenItem.value as double : 1.0;
     final radius = borderTokenItem.sectionName == BorderSection.radius ? borderTokenItem.value as double : 1.0;
     final isDashed = borderTokenItem.sectionName == BorderSection.style && borderTokenItem.value == "dashed";
+    final isSolid = borderTokenItem.sectionName == BorderSection.style && borderTokenItem.value == "solid";
 
     final borderRadius = BorderRadius.circular(radius);
 
@@ -150,7 +151,7 @@ class BorderWidget extends StatelessWidget {
                     border: Border.all(
                       color: color,
                       width: width,
-                      style: borderTokenItem.sectionName == BorderSection.style && borderTokenItem.value == "solid" ? BorderStyle.solid : BorderStyle.solid,
+                      style: isSolid ? BorderStyle.solid : BorderStyle.solid,
                     ),
                   ),
                 ),

--- a/app/lib/ui/tokens/tokens.dart
+++ b/app/lib/ui/tokens/tokens.dart
@@ -12,6 +12,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
+import 'package:ouds_flutter_demo/ui/tokens/border/border_screen.dart';
 import 'package:ouds_flutter_demo/ui/tokens/color/color_screen.dart';
 import 'package:ouds_flutter_demo/ui/tokens/elevation/elevation_screen.dart';
 import 'package:ouds_flutter_demo/ui/tokens/opacity/opacity_screen.dart';
@@ -22,6 +23,12 @@ import 'package:ouds_flutter_demo/ui/utilities/app_assets.dart';
 
 List<Token> tokens(BuildContext context) {
   return [
+    Token(
+      context.l10n.app_tokens_border_label,
+      AdaptiveImageHelper.getImage(context, AppAssets.images.ilBorder),
+      context.l10n.app_tokens_border_description_text,
+      BorderScreen(illustration: AppAssets.images.ilBorder),
+    ),
     Token(
       context.l10n.app_tokens_elevation_label,
       AdaptiveImageHelper.getImage(context, AppAssets.images.ilTokensElevation),

--- a/app/lib/ui/tokens/tokens.dart
+++ b/app/lib/ui/tokens/tokens.dart
@@ -25,9 +25,9 @@ List<Token> tokens(BuildContext context) {
   return [
     Token(
       context.l10n.app_tokens_border_label,
-      AdaptiveImageHelper.getImage(context, AppAssets.images.ilBorder),
+      AdaptiveImageHelper.getImage(context, AppAssets.images.ilTokenBorder),
       context.l10n.app_tokens_border_description_text,
-      BorderScreen(illustration: AppAssets.images.ilBorder),
+      BorderScreen(illustration: AppAssets.images.ilTokenBorder),
     ),
     Token(
       context.l10n.app_tokens_elevation_label,

--- a/app/lib/ui/utilities/app_assets.dart
+++ b/app/lib/ui/utilities/app_assets.dart
@@ -41,10 +41,8 @@ class _Images {
   final String ilComponentsSwitch = 'assets/il_components_switch.svg';
   final String ilComponentsSwitchDark = 'assets/il_components_switch_dark.svg';
 
-  final String ilComponentsChip =
-      'assets/il_components_chip.svg';
-  final String ilComponentsChipDark =
-      'assets/il_components_chip_dark.svg';
+  final String ilComponentsChip = 'assets/il_components_chip.svg';
+  final String ilComponentsChipDark = 'assets/il_components_chip_dark.svg';
 
   /// Tokens
   final String ilTokensColor = 'assets/il_tokens_color.svg';
@@ -61,6 +59,9 @@ class _Images {
 
   final String ilTypography = 'assets/il_tokens_typography.svg';
   final String ilTypographyDark = 'assets/il_tokens_typography_dark.svg';
+
+  final String ilBorder = 'assets/il_tokens_border.svg';
+  final String ilBorderDark = 'assets/il_tokens_border_dark.svg';
 }
 
 class _Icons {

--- a/app/lib/ui/utilities/app_assets.dart
+++ b/app/lib/ui/utilities/app_assets.dart
@@ -60,8 +60,8 @@ class _Images {
   final String ilTypography = 'assets/il_tokens_typography.svg';
   final String ilTypographyDark = 'assets/il_tokens_typography_dark.svg';
 
-  final String ilBorder = 'assets/il_tokens_border.svg';
-  final String ilBorderDark = 'assets/il_tokens_border_dark.svg';
+  final String ilTokenBorder = 'assets/il_tokens_border.svg';
+  final String ilTokenBorderDark = 'assets/il_tokens_border_dark.svg';
 }
 
 class _Icons {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.2
+  dotted_border: ^2.0.0
   flutter_svg: ^2.2.0
   # Read markdown.
   markdown: ^7.1.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.4"
+  dotted_border:
+    dependency: transitive
+    description:
+      name: dotted_border
+      sha256: "108837e11848ca776c53b30bc870086f84b62ed6e01c503ed976e8f8c7df9c04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -333,6 +341,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#248 

### Description

Display token border

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [x] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
