### PR TITLE
[Bug][DemoApp] Bottom sheet is expanded by default 

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [DemoApp] Replace components illustrations by the components themselves ([#247](https://github.com/Orange-OpenSource/ouds-flutter/issues/247))
 - [DemoApp] Replace app icon with Flutter icon for Design Toolbox ([#268](https://github.com/Orange-OpenSource/ouds-flutter/issues/268))
 
+### Fixed
+- [DemoApp] the bottom sheet should be closed by default for a11y ([#263](https://github.com/Orange-OpenSource/ouds-flutter/issues/263))
+
 ## [0.4.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...0.4.0) - 2025-07-11
 
 ### Added

--- a/app/lib/ui/components/badge/badge_demo_screen.dart
+++ b/app/lib/ui/components/badge/badge_demo_screen.dart
@@ -45,7 +45,7 @@ class BadgeDemoScreen extends StatefulWidget {
 
 class _BadgeDemoScreenState extends State<BadgeDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -42,7 +42,7 @@ class ButtonDemoScreen extends StatefulWidget {
 
 class _ButtonDemoScreenState extends State<ButtonDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_demo_screen.dart
@@ -39,7 +39,7 @@ class CheckboxDemoScreen extends StatefulWidget {
 
 class _CheckboxDemoScreenState extends State<CheckboxDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
+++ b/app/lib/ui/components/checkbox/checkbox_item_demo_screen.dart
@@ -45,7 +45,7 @@ class ControlItemDemoScreen extends StatefulWidget {
 
 class _ControlItemDemoScreenState extends State<ControlItemDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
+++ b/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
@@ -39,17 +39,29 @@ class ChipFilterDemoScreen extends StatefulWidget {
 }
 
 class _ChipFilterDemoScreenState extends State<ChipFilterDemoScreen> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  bool _isBottomSheetExpanded = true;
+
+  void _onExpansionChanged(bool isExpanded) {
+    setState(() {
+      _isBottomSheetExpanded = isExpanded;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return ChipCustomization(
+      key: _scaffoldKey,
       child: Scaffold(
         bottomSheet: OudsSheetsBottom(
+          onExpansionChanged: _onExpansionChanged,
           sheetContent: const _CustomizationContent(),
           title: context.l10n.app_common_customize_label,
         ),
         appBar: MainAppBar(title: context.l10n.app_components_filterChip_label),
         body: SafeArea(
           child: ExcludeSemantics(
+            excluding: !_isBottomSheetExpanded,
             child: _Body(),
           ),
         ),

--- a/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
@@ -39,17 +39,29 @@ class ChipSuggestionDemoScreen extends StatefulWidget {
 }
 
 class _ChipSuggestionDemoScreenState extends State<ChipSuggestionDemoScreen> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  bool _isBottomSheetExpanded = true;
+
+  void _onExpansionChanged(bool isExpanded) {
+    setState(() {
+      _isBottomSheetExpanded = isExpanded;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return ChipCustomization(
+      key: _scaffoldKey,
       child: Scaffold(
         bottomSheet: OudsSheetsBottom(
+          onExpansionChanged: _onExpansionChanged,
           sheetContent: const _CustomizationContent(),
           title: context.l10n.app_common_customize_label,
         ),
-        appBar: MainAppBar(title: context.l10n.app_components_suggestionChip_label),
+        appBar: MainAppBar(title: context.l10n.app_components_filterChip_label),
         body: SafeArea(
           child: ExcludeSemantics(
+            excluding: !_isBottomSheetExpanded,
             child: _Body(),
           ),
         ),

--- a/app/lib/ui/components/divider/divider_demo_screen.dart
+++ b/app/lib/ui/components/divider/divider_demo_screen.dart
@@ -28,7 +28,7 @@ class DividerDemoScreen extends StatefulWidget {
 
 class _DividerDemoScreenState extends State<DividerDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_demo_screen.dart
@@ -42,7 +42,7 @@ class RadioButtonDemoScreen extends StatefulWidget {
 
 class _RadioButtonDemoScreenState extends State<RadioButtonDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
+++ b/app/lib/ui/components/radio_button/radio_button_item_demo_screen.dart
@@ -46,7 +46,7 @@ class RadioButtonItemDemoScreen extends StatefulWidget {
 
 class _RadioButtonDemoScreenState extends State<RadioButtonItemDemoScreen> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  bool _isBottomSheetExpanded = false;
+  bool _isBottomSheetExpanded = true;
 
   void _onExpansionChanged(bool isExpanded) {
     setState(() {

--- a/app/lib/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart
+++ b/app/lib/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart
@@ -41,7 +41,7 @@ class OudsSheetsBottom extends StatefulWidget {
 }
 
 class OudsSheetsBottomState extends State<OudsSheetsBottom> {
-  bool expanded = false;
+  bool expanded = true;
   double chevronTurns = 0.0;
 
   void _changeChevronRotation() {

--- a/app/lib/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart
+++ b/app/lib/ui/utilities/sheets_bottom/ouds_sheets_bottom.dart
@@ -42,7 +42,7 @@ class OudsSheetsBottom extends StatefulWidget {
 
 class OudsSheetsBottomState extends State<OudsSheetsBottom> {
   bool expanded = true;
-  double chevronTurns = 0.0;
+  double chevronTurns = 0.5;
 
   void _changeChevronRotation() {
     setState(() => chevronTurns += 0.5);
@@ -85,7 +85,7 @@ class OudsSheetsBottomState extends State<OudsSheetsBottom> {
         ),
         child: AnimatedContainer(
           duration: const Duration(seconds: 11150),
-          height: expanded ? collapsedHeight : null,
+          height: !expanded ? collapsedHeight : null,
           constraints: BoxConstraints(
             maxHeight: MediaQuery.of(context).size.height * 0.5,
           ),


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#263 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [x] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [x] Design review
- [x] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
