### PR TITLE
bug: wrong role for checkbox a11y

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [DemoApp] Replace app icon with Flutter icon for Design Toolbox ([#268](https://github.com/Orange-OpenSource/ouds-flutter/issues/268))
 
 ### Fixed
+- [Library] wrong role for checkbox a11y ([#261](https://github.com/Orange-OpenSource/ouds-flutter/issues/261))
 - [DemoApp] the bottom sheet should be closed by default for a11y ([#263](https://github.com/Orange-OpenSource/ouds-flutter/issues/263))
 
 ## [0.4.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...0.4.0) - 2025-07-11

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.4.0...develop)
 
+### Fixed
+- [Library] wrong role for checkbox a11y ([#261](https://github.com/Orange-OpenSource/ouds-flutter/issues/261))
+
 ## [0.4.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...0.4.0) - 2025-07-11
 
 ### Added

--- a/ouds_core/lib/components/checkbox/ouds_checkbox.dart
+++ b/ouds_core/lib/components/checkbox/ouds_checkbox.dart
@@ -18,6 +18,7 @@ import 'package:ouds_core/components/control/internal/modifier/ouds_control_bord
 import 'package:ouds_core/components/control/internal/modifier/ouds_control_tick_modifier.dart';
 import 'package:ouds_core/components/control/internal/ouds_control_state.dart';
 import 'package:ouds_core/components/utilities/app_assets.dart';
+import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 enum ToggleableState { off, indeterminate, on }
@@ -98,10 +99,13 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
     final checkboxBackgroundModifier = OudsControlBackgroundModifier(context);
     final checkboxTickModifier = OudsControlTickModifier(context);
     final checkbox = OudsTheme.of(context).componentsTokens(context).checkbox;
+    final l10n = OudsLocalizations.of(context);
 
     return Semantics(
       enabled: widget.onChanged != null,
-      checked: widget.value == true,
+      value: widget.value == true ? l10n?.core_components_checkbox_checked_a11y : l10n?.core_components_checkbox_not_checked_a11y,
+      label: widget.tristate == true ? l10n?.core_components_checkbox_indeterminateCheckbox_a11y : l10n?.core_components_checkbox_checkbox_a11y,
+      hint: widget.isError ? l10n?.core_components_checkbox_error_a11y : null,
       child: Material(
         color: Colors.transparent,
         child: SizedBox(

--- a/ouds_core/lib/l10n/gen/ouds_localizations.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations.dart
@@ -133,6 +133,54 @@ abstract class OudsLocalizations {
   /// In en, this message translates to:
   /// **'Tap to expand or collapse the bottom sheet'**
   String get core_bottom_sheets_hint_a11y;
+
+  /// No description provided for @core_chip_icon_only_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Icon'**
+  String get core_chip_icon_only_a11y;
+
+  /// No description provided for @core_chip_text_only_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Text'**
+  String get core_chip_text_only_a11y;
+
+  /// No description provided for @core_chip_text_and_icon_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Text and Icon'**
+  String get core_chip_text_and_icon_a11y;
+
+  /// No description provided for @core_components_checkbox_checkbox_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Checkbox'**
+  String get core_components_checkbox_checkbox_a11y;
+
+  /// No description provided for @core_components_checkbox_indeterminateCheckbox_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Indeterminate checkbox'**
+  String get core_components_checkbox_indeterminateCheckbox_a11y;
+
+  /// No description provided for @core_components_checkbox_checked_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Checked'**
+  String get core_components_checkbox_checked_a11y;
+
+  /// No description provided for @core_components_checkbox_not_checked_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Not checked'**
+  String get core_components_checkbox_not_checked_a11y;
+
+  /// No description provided for @core_components_checkbox_error_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get core_components_checkbox_error_a11y;
 }
 
 class _OudsLocalizationsDelegate

--- a/ouds_core/lib/l10n/gen/ouds_localizations_ar.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations_ar.dart
@@ -26,4 +26,29 @@ class OudsLocalizationsAr extends OudsLocalizations {
   @override
   String get core_bottom_sheets_hint_a11y =>
       'اضغط لتوسيع أو طي النافذة السفلية';
+
+  @override
+  String get core_chip_icon_only_a11y => 'أيقونة';
+
+  @override
+  String get core_chip_text_only_a11y => 'نص';
+
+  @override
+  String get core_chip_text_and_icon_a11y => 'نص وأيقونة';
+
+  @override
+  String get core_components_checkbox_checkbox_a11y => 'خانة الاختيار';
+
+  @override
+  String get core_components_checkbox_indeterminateCheckbox_a11y =>
+      'خانة اختيار ثلاثية الحالات';
+
+  @override
+  String get core_components_checkbox_checked_a11y => 'تم الفحص';
+
+  @override
+  String get core_components_checkbox_not_checked_a11y => 'لم يتم التحقق منها';
+
+  @override
+  String get core_components_checkbox_error_a11y => 'خطأ';
 }

--- a/ouds_core/lib/l10n/gen/ouds_localizations_en.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations_en.dart
@@ -26,4 +26,29 @@ class OudsLocalizationsEn extends OudsLocalizations {
   @override
   String get core_bottom_sheets_hint_a11y =>
       'Tap to expand or collapse the bottom sheet';
+
+  @override
+  String get core_chip_icon_only_a11y => 'Icon';
+
+  @override
+  String get core_chip_text_only_a11y => 'Text';
+
+  @override
+  String get core_chip_text_and_icon_a11y => 'Text and Icon';
+
+  @override
+  String get core_components_checkbox_checkbox_a11y => 'Checkbox';
+
+  @override
+  String get core_components_checkbox_indeterminateCheckbox_a11y =>
+      'Indeterminate checkbox';
+
+  @override
+  String get core_components_checkbox_checked_a11y => 'Checked';
+
+  @override
+  String get core_components_checkbox_not_checked_a11y => 'Not checked';
+
+  @override
+  String get core_components_checkbox_error_a11y => 'Error';
 }

--- a/ouds_core/lib/l10n/ouds_flutter_ar.arb
+++ b/ouds_core/lib/l10n/ouds_flutter_ar.arb
@@ -12,5 +12,12 @@
     "@_OUDS_CHIP": {},
     "core_chip_icon_only_a11y": "أيقونة",
     "core_chip_text_only_a11y": "نص",
-    "core_chip_text_and_icon_a11y": "نص وأيقونة"
+    "core_chip_text_and_icon_a11y": "نص وأيقونة",
+
+    "@_OUDS_Checkbox": {},
+    "core_components_checkbox_checkbox_a11y":  "خانة الاختيار",
+    "core_components_checkbox_indeterminateCheckbox_a11y": "خانة اختيار ثلاثية الحالات",
+    "core_components_checkbox_checked_a11y": "تم الفحص",
+    "core_components_checkbox_not_checked_a11y": "لم يتم التحقق منها",
+    "core_components_checkbox_error_a11y": "خطأ"
 }

--- a/ouds_core/lib/l10n/ouds_flutter_en.arb
+++ b/ouds_core/lib/l10n/ouds_flutter_en.arb
@@ -12,6 +12,12 @@
     "@_OUDS_CHIP": {},
     "core_chip_icon_only_a11y": "Icon",
     "core_chip_text_only_a11y": "Text",
-    "core_chip_text_and_icon_a11y": "Text and Icon"
+    "core_chip_text_and_icon_a11y": "Text and Icon",
 
+    "@_OUDS_Checkbox": {},
+    "core_components_checkbox_checkbox_a11y":  "Checkbox",
+    "core_components_checkbox_indeterminateCheckbox_a11y": "Indeterminate checkbox",
+    "core_components_checkbox_checked_a11y": "Checked",
+    "core_components_checkbox_not_checked_a11y": "Not checked",
+    "core_components_checkbox_error_a11y": "Error"
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#261 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
