### PR TITLE
feat : update component button 3.0

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [DemoApp][Library] Integration of Sosh theme ([#262](https://github.com/Orange-OpenSource/ouds-flutter/issues/262))
 
 ### Changed
+- [DemoApp][Library] Update component - `Button version 3.0` ([#279](https://github.com/Orange-OpenSource/ouds-flutter/issues/279))
 - [DemoApp][Library] Refactor with custom configuration Rounded `Button`, `Tag` and `TextInput` ([#299](-https://github.com/Orange-OpenSource/ouds-flutter/issues/299))
 - [Library] Refactor `Chip` and `Button` classes name ([#298](-https://github.com/Orange-OpenSource/ouds-flutter/issues/298))
 - [DemoApp] Include Design Component version in Design Toolbox App ([#240](https://github.com/Orange-OpenSource/ouds-flutter/issues/240))

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -59,7 +59,7 @@ class _OudsApplicationState extends State<OudsApplication> {
                     ? TextDirection.rtl // If the language is RTL, use TextDirection.rtl
                     : TextDirection.ltr, // Otherwise, use TextDirection.ltr
                 child: OudsThemeConfigModel(
-                  button: OudsButtonConfig(rounded: true),
+                  button: OudsButtonConfig(rounded: themeController.onBorderRadiusButtonState),
                   tag: OudsTagConfig(rounded: themeController.onBorderRadiusTagState),
                   textInput: OudsTextInputConfig(rounded: false),
                   child: OudsTheme(

--- a/app/lib/ui/components/button/button_code_generator.dart
+++ b/app/lib/ui/components/button/button_code_generator.dart
@@ -41,18 +41,15 @@ class ButtonCodeGenerator {
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsButtonLayout.textOnly:
-        code =
-            """${coloredSurfaceCodeModifier(context)}OudsButton(\nlabel: "$label",\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nlabel: "$label",\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconOnly:
-        code =
-            """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: Icon(Icons.favorite_border),\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconAndText:
-        code =
-            """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: Icon(Icons.favorite_border),\nlabel: "$label",\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nhierarchy: ${hierarchy.toString()},\nstyle: ${style.toString()},\n${disableCode(context)}""";
         break;
     }
 

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -85,6 +85,7 @@ class HierarchyState {
   List<ButtonEnumHierarchy> _hierarchy = [
     ButtonEnumHierarchy.defaultHierarchy,
     ButtonEnumHierarchy.strong,
+    ButtonEnumHierarchy.brand,
     ButtonEnumHierarchy.minimal,
     ButtonEnumHierarchy.negative,
   ];

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -37,6 +37,7 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
   late final HierarchyState hierarchyState;
   late final StyleState styleState;
   late final LayoutState layoutState;
+  late final RoundedCornerState roundedCornerState;
 
   @override
   void initState() {
@@ -44,6 +45,7 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
     hierarchyState = HierarchyState(setState, onColoredBoxState);
     styleState = StyleState(setState, enabledState);
     layoutState = LayoutState(setState);
+    roundedCornerState = RoundedCornerState(setState);
   }
 
   // Getter to determine if the 'OnColoredBox' should be disabled
@@ -65,6 +67,9 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
 
   ButtonEnumLayout get selectedLayout => layoutState.selected;
   set selectedLayout(ButtonEnumLayout value) => layoutState.selected = value;
+
+  bool get hasRoundedCorner => roundedCornerState.value;
+  set hasRoundedCorner(bool value) => roundedCornerState.value = value;
 
   @override
   Widget build(BuildContext context) {
@@ -162,6 +167,21 @@ class LayoutState {
   set selected(ButtonEnumLayout newValue) {
     _setState(() {
       _selected = newValue;
+    });
+  }
+}
+
+/// RoundedCorner State Management
+class RoundedCornerState {
+  RoundedCornerState(this._setState);
+
+  final void Function(void Function()) _setState;
+  bool _hasRoundedCorner = true;
+
+  bool get value => _hasRoundedCorner;
+  set value(bool newValue) {
+    _setState(() {
+      _hasRoundedCorner = newValue;
     });
   }
 }

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -176,7 +176,7 @@ class RoundedCornerState {
   RoundedCornerState(this._setState);
 
   final void Function(void Function()) _setState;
-  bool _hasRoundedCorner = true;
+  bool _hasRoundedCorner = false;
 
   bool get value => _hasRoundedCorner;
   set value(bool newValue) {

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -170,7 +170,7 @@ class LayoutState {
 class ButtonErrorCases {
   // OnColoredBox behavior: Disable if hierarchy is 'Negative'
   static bool isOnColoredBoxDisabled(ButtonEnumHierarchy hierarchy) {
-    return hierarchy == ButtonEnumHierarchy.negative;
+    return hierarchy == ButtonEnumHierarchy.negative || hierarchy == ButtonEnumHierarchy.brand;
   }
 
   // OnColoredBox management: Disable when "Negative" hierarchy is selected

--- a/app/lib/ui/components/button/button_customization_utils.dart
+++ b/app/lib/ui/components/button/button_customization_utils.dart
@@ -32,6 +32,8 @@ class ButtonCustomizationUtils {
         return OudsButtonHierarchy.negative;
       case ButtonEnumHierarchy.strong:
         return OudsButtonHierarchy.strong;
+      case ButtonEnumHierarchy.brand:
+        return OudsButtonHierarchy.brand;
       default:
         return OudsButtonHierarchy.defaultHierarchy;
     }

--- a/app/lib/ui/components/button/button_customization_utils.dart
+++ b/app/lib/ui/components/button/button_customization_utils.dart
@@ -10,10 +10,10 @@
 // Software description: Flutter library of reusable graphical components
 //
 
-import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_flutter_demo/ui/components/button/button_customization.dart';
 import 'package:ouds_flutter_demo/ui/components/button/button_enum.dart';
+import 'package:ouds_flutter_demo/ui/utilities/app_assets.dart';
 
 /// Utility class to map button customization options to corresponding OudsButton attributes.
 ///
@@ -64,9 +64,9 @@ class ButtonCustomizationUtils {
   }
 
   /// Determines the icon to display based on the selected layout.
-  static Widget? getIcon(ButtonCustomizationState? customizationState) {
+  static String? getIcon(ButtonCustomizationState? customizationState) {
     if (customizationState?.selectedLayout == ButtonEnumLayout.iconOnly || customizationState?.selectedLayout == ButtonEnumLayout.iconAndText) {
-      return const Icon(Icons.favorite_border);
+      return AppAssets.icons.icHeart;
     }
     return null;
   }

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -125,7 +125,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
         color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
         child: OudsButton(
           label: ButtonCustomizationUtils.getText(customizationState),
-          icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
+          icon: ButtonCustomizationUtils.getIcon(customizationState),
           hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
           style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
@@ -140,7 +140,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
             child: OudsButton(
               label: ButtonCustomizationUtils.getText(customizationState),
-              icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
+              icon: ButtonCustomizationUtils.getIcon(customizationState),
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
@@ -151,7 +151,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
             child: OudsButton(
               label: ButtonCustomizationUtils.getText(customizationState),
-              icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
+              icon: ButtonCustomizationUtils.getIcon(customizationState),
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -125,7 +125,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
         color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
         child: OudsButton(
           label: ButtonCustomizationUtils.getText(customizationState),
-          icon: ButtonCustomizationUtils.getIcon(customizationState),
+          icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
           hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
           style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
@@ -140,11 +140,10 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             themeMode: themeController!.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
             child: OudsButton(
               label: ButtonCustomizationUtils.getText(customizationState),
-              icon: ButtonCustomizationUtils.getIcon(customizationState),
+              icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
-              border: customizationState?.hasBorderRounded == true ? OudsButtonBorder.radiusRounded : OudsButtonBorder.radiusDefault,
             ),
           ),
           ThemeBox(
@@ -152,11 +151,10 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
             child: OudsButton(
               label: ButtonCustomizationUtils.getText(customizationState),
-              icon: ButtonCustomizationUtils.getIcon(customizationState),
+              icon: /*AppAssets.icons.icHeart,*/ ButtonCustomizationUtils.getIcon(customizationState),
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
-              border: customizationState?.hasBorderRounded == true ? OudsButtonBorder.radiusRounded : OudsButtonBorder.radiusDefault,
             ),
           )
         ],

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -144,6 +144,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
+              border: customizationState?.hasBorderRounded == true ? OudsButtonBorder.radiusRounded : OudsButtonBorder.radiusDefault,
             ),
           ),
           ThemeBox(
@@ -155,6 +156,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
               hierarchy: ButtonCustomizationUtils.getHierarchy(customizationState?.selectedHierarchy as Object),
               style: ButtonCustomizationUtils.getStyle(customizationState?.selectedStyle as Object),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
+              border: customizationState?.hasBorderRounded == true ? OudsButtonBorder.radiusRounded : OudsButtonBorder.radiusDefault,
             ),
           )
         ],
@@ -205,6 +207,13 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                   : (value) {
                       customizationState.hasOnColoredBox = value;
                     },
+        ),
+        CustomizableSwitch(
+          title: "Rounded",
+          value: customizationState.hasBorderRounded,
+          onChanged: (value) {
+            customizationState.hasBorderRounded = value;
+          },
         ),
         CustomizableChips<ButtonEnumHierarchy>(
           title: ButtonEnumHierarchy.enumName(context),

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -188,8 +188,15 @@ class _CustomizationContentState extends State<_CustomizationContent> {
     return CustomizableSection(
       children: [
         CustomizableSwitch(
+          title: context.l10n.app_components_common_roundedCorner_label,
+          value: customizationState!.hasRoundedCorner,
+          onChanged: (value) {
+            customizationState.hasRoundedCorner = value;
+          },
+        ),
+        CustomizableSwitch(
           title: context.l10n.app_common_enabled_label,
-          value: customizationState!.hasEnabled,
+          value: customizationState.hasEnabled,
           onChanged:
 
               /// Specific case: Enabled disabled if style is 'Loading'
@@ -210,13 +217,6 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                   : (value) {
                       customizationState.hasOnColoredBox = value;
                     },
-        ),
-        CustomizableSwitch(
-          title: context.l10n.app_components_common_roundedCorner_label,
-          value: customizationState.hasRoundedCorner,
-          onChanged: (value) {
-            customizationState.hasRoundedCorner = value;
-          },
         ),
         CustomizableChips<ButtonEnumHierarchy>(
           title: ButtonEnumHierarchy.enumName(context),

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -120,6 +120,11 @@ class _ButtonDemoState extends State<_ButtonDemo> {
       themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
     });
 
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnBorderRadiusButtonState(customizationState?.hasRoundedCorner);
+    });
+
     if (customizationState?.hasOnColoredBox == true) {
       return OudsColoredBox(
         color: customizationState?.hasOnColoredBox == true ? OudsColoredBoxColor.brandPrimary : OudsColoredBoxColor.statusNeutralMuted,
@@ -207,10 +212,10 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                     },
         ),
         CustomizableSwitch(
-          title: "Rounded",
-          value: customizationState.hasBorderRounded,
+          title: context.l10n.app_components_common_roundedCorner_label,
+          value: customizationState.hasRoundedCorner,
           onChanged: (value) {
-            customizationState.hasBorderRounded = value;
+            customizationState.hasRoundedCorner = value;
           },
         ),
         CustomizableChips<ButtonEnumHierarchy>(

--- a/app/lib/ui/components/button/button_enum.dart
+++ b/app/lib/ui/components/button/button_enum.dart
@@ -36,6 +36,7 @@ String capitalizeEnumValue(Enum enumValue) {
 enum ButtonEnumHierarchy {
   defaultHierarchy,
   strong,
+  brand,
   minimal,
   negative;
 
@@ -51,6 +52,8 @@ extension CustomElementHierarchy on ButtonEnumHierarchy {
         return capitalizeEnumValue(ButtonEnumHierarchy.defaultHierarchy);
       case ButtonEnumHierarchy.strong:
         return capitalizeEnumValue(ButtonEnumHierarchy.strong);
+      case ButtonEnumHierarchy.brand:
+        return capitalizeEnumValue(ButtonEnumHierarchy.brand);
       case ButtonEnumHierarchy.minimal:
         return capitalizeEnumValue(ButtonEnumHierarchy.minimal);
       case ButtonEnumHierarchy.negative:

--- a/app/lib/ui/theme/theme_controller.dart
+++ b/app/lib/ui/theme/theme_controller.dart
@@ -20,7 +20,7 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
   OudsThemeContract _currentTheme = OrangeTheme();
   bool _onColoredSurface = false;
   bool _onBorderRadiusTagState = true;
-  bool _onBorderRadiusButtonState = true;
+  bool _onBorderRadiusButtonState = false;
 
   /// Getter to access the current theme
   OudsThemeContract get currentTheme => _currentTheme;

--- a/app/lib/ui/theme/theme_controller.dart
+++ b/app/lib/ui/theme/theme_controller.dart
@@ -20,6 +20,7 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
   OudsThemeContract _currentTheme = OrangeTheme();
   bool _onColoredSurface = false;
   bool _onBorderRadiusTagState = true;
+  bool _onBorderRadiusButtonState = true;
 
   /// Getter to access the current theme
   OudsThemeContract get currentTheme => _currentTheme;
@@ -32,6 +33,7 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Getter to know if we are on a border state
   bool get onBorderRadiusTagState => _onBorderRadiusTagState;
+  bool get onBorderRadiusButtonState => _onBorderRadiusButtonState;
 
   ThemeController() {
     /// Initialize the theme based on the system's current brightness setting
@@ -92,10 +94,19 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
     }
   }
 
+  /// Changes the border state
   void setOnBorderRadiusTagState(bool? value) {
     bool newValue = value ?? false;
     if (_onBorderRadiusTagState != newValue) {
       _onBorderRadiusTagState = newValue;
+      notifyListeners();
+    }
+  }
+
+  void setOnBorderRadiusButtonState(bool? value) {
+    bool newValue = value ?? false;
+    if (_onBorderRadiusButtonState != newValue) {
+      _onBorderRadiusButtonState = newValue;
       notifyListeners();
     }
   }

--- a/app/lib/ui/utilities/customizable/customizable_widget_state.dart
+++ b/app/lib/ui/utilities/customizable/customizable_widget_state.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<T> {
   late final EnabledState enabledState;
   late final OnColoredBoxState onColoredBoxState;
+  late final OnBorderRadiusState onBorderRadiusState;
   late final TextState textState;
   late final SelectState selectState;
 
@@ -24,6 +25,7 @@ abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<
     super.initState();
     enabledState = EnabledState(setState);
     onColoredBoxState = OnColoredBoxState(setState);
+    onBorderRadiusState = OnBorderRadiusState(setState);
     textState = TextState(setState);
     selectState = SelectState(setState);
   }
@@ -34,6 +36,9 @@ abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<
 
   bool get hasOnColoredBox => onColoredBoxState.value;
   set hasOnColoredBox(bool value) => onColoredBoxState.value = value;
+
+  bool get hasBorderRounded => onBorderRadiusState.value;
+  set hasBorderRounded(bool value) => onBorderRadiusState.value = value;
 
   String get textValue => textState.value;
   set textValue(String value) => textState.value = value;
@@ -68,6 +73,21 @@ class OnColoredBoxState {
   set value(bool newValue) {
     _setState(() {
       _hasOnColoredBox = newValue;
+    });
+  }
+}
+
+/// Enabled State Management
+class OnBorderRadiusState {
+  OnBorderRadiusState(this._setState);
+
+  final void Function(void Function()) _setState;
+  bool _hasRounded = true;
+
+  bool get value => _hasRounded;
+  set value(bool newValue) {
+    _setState(() {
+      _hasRounded = newValue;
     });
   }
 }

--- a/app/lib/ui/utilities/customizable/customizable_widget_state.dart
+++ b/app/lib/ui/utilities/customizable/customizable_widget_state.dart
@@ -16,7 +16,6 @@ import 'package:flutter/material.dart';
 abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<T> {
   late final EnabledState enabledState;
   late final OnColoredBoxState onColoredBoxState;
-  late final OnBorderRadiusState onBorderRadiusState;
   late final TextState textState;
   late final SelectState selectState;
 
@@ -25,7 +24,6 @@ abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<
     super.initState();
     enabledState = EnabledState(setState);
     onColoredBoxState = OnColoredBoxState(setState);
-    onBorderRadiusState = OnBorderRadiusState(setState);
     textState = TextState(setState);
     selectState = SelectState(setState);
   }
@@ -36,9 +34,6 @@ abstract class CustomizationWidgetState<T extends StatefulWidget> extends State<
 
   bool get hasOnColoredBox => onColoredBoxState.value;
   set hasOnColoredBox(bool value) => onColoredBoxState.value = value;
-
-  bool get hasBorderRounded => onBorderRadiusState.value;
-  set hasBorderRounded(bool value) => onBorderRadiusState.value = value;
 
   String get textValue => textState.value;
   set textValue(String value) => textState.value = value;
@@ -73,21 +68,6 @@ class OnColoredBoxState {
   set value(bool newValue) {
     _setState(() {
       _hasOnColoredBox = newValue;
-    });
-  }
-}
-
-/// Enabled State Management
-class OnBorderRadiusState {
-  OnBorderRadiusState(this._setState);
-
-  final void Function(void Function()) _setState;
-  bool _hasRounded = true;
-
-  bool get value => _hasRounded;
-  set value(bool newValue) {
-    _setState(() {
-      _hasRounded = newValue;
     });
   }
 }

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Library] FWrong token used in tag input for disabled status ([#310](https://github.com/Orange-OpenSource/ouds-flutter/issues/310))
 - [Library] wrong role for checkbox a11y ([#261](https://github.com/Orange-OpenSource/ouds-flutter/issues/261))
+- 
+### Changed
+- [Library] Update component - Button version 3.0 ([#279](https://github.com/Orange-OpenSource/ouds-flutter/issues/279))
 
 ### Changed
 - [Library] Refactor with custom configuration Rounded `Button`, `Tag` and `TextInput` ([#299](-https://github.com/Orange-OpenSource/ouds-flutter/issues/299))

--- a/ouds_core/lib/components/button/internal/button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_icon_modifier.dart
@@ -25,19 +25,16 @@ class OudsButtonIconModifier {
     if (style == OudsButtonStyle.loading) {
       return ButtonLoadingModifier.getColorToken(context, hierarchy);
     }
-    print("states: $states");
     switch (states) {
       case OudsButtonControlState.enabled:
         return _getEnabledIconColor(context, hierarchy);
       case OudsButtonControlState.hovered:
-        return Colors.yellow;
+        //return Colors.yellow;
         return _getHoverIconColor(context, hierarchy);
       case OudsButtonControlState.pressed:
-        return Colors.red;
-      //    return _getPressedIconColor(context, hierarchy);
+        return _getPressedIconColor(context, hierarchy);
       case OudsButtonControlState.disabled:
-        return Colors.blue;
-      // return _getDisabledIconColor(context, hierarchy);
+        return _getDisabledIconColor(context, hierarchy);
     }
   }
 

--- a/ouds_core/lib/components/button/internal/button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_icon_modifier.dart
@@ -124,7 +124,8 @@ class OudsButtonIconModifier {
       case OudsButtonLayout.iconAndText:
         return buttonToken.sizeIcon;
       case OudsButtonLayout.textOnly:
-        return 0.0;
+        // TODO: Handle this case.
+        throw UnimplementedError();
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_icon_modifier.dart
@@ -13,23 +13,28 @@
 
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/internal/button_loading_modifier.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
+/// Class responsible for modifying the icon appearance of an Ouds button based on its state and context.
 class OudsButtonIconModifier {
   final BuildContext context;
 
+  /// Constructor that takes the build context.
   OudsButtonIconModifier(this.context);
 
+  /// Static method to get the icon color based on button state, hierarchy, and style.
   static Color getIconColor(BuildContext context, OudsButtonControlState states, OudsButtonHierarchy hierarchy, OudsButtonStyle? style) {
     if (style == OudsButtonStyle.loading) {
+      // If the button is in loading style, get the loading color token.
       return ButtonLoadingModifier.getColorToken(context, hierarchy);
     }
+    // Determine icon color based on the current control state.
     switch (states) {
       case OudsButtonControlState.enabled:
         return _getEnabledIconColor(context, hierarchy);
       case OudsButtonControlState.hovered:
-        //return Colors.yellow;
         return _getHoverIconColor(context, hierarchy);
       case OudsButtonControlState.pressed:
         return _getPressedIconColor(context, hierarchy);
@@ -38,7 +43,7 @@ class OudsButtonIconModifier {
     }
   }
 
-  /// Color icon color based on button state and selection
+  /// Private static method to get the icon color when the button is enabled.
   static Color _getEnabledIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
@@ -56,6 +61,7 @@ class OudsButtonIconModifier {
     }
   }
 
+  /// Private static method to get the icon color when the button is hovered.
   static Color _getHoverIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
@@ -73,6 +79,7 @@ class OudsButtonIconModifier {
     }
   }
 
+  /// Private static method to get the icon color when the button is pressed.
   static Color _getPressedIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
@@ -90,6 +97,7 @@ class OudsButtonIconModifier {
     }
   }
 
+  /// Private static method to get the icon color when the button is disabled.
   static Color _getDisabledIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
@@ -107,6 +115,7 @@ class OudsButtonIconModifier {
     }
   }
 
+  /// Static method to get the icon size based on button layout.
   static double getIconSize(BuildContext context, OudsButtonLayout layout) {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
     switch (layout) {
@@ -117,36 +126,5 @@ class OudsButtonIconModifier {
       case OudsButtonLayout.textOnly:
         return 0.0;
     }
-  }
-}
-
-// TODO: create new file for this class
-
-/// Enum representing the state of the chip control.
-enum OudsButtonControlState {
-  enabled,
-  hovered,
-  pressed,
-  disabled,
-}
-
-/// A class that determines the state of the OudsChip
-class OudsButtonControlStateDeterminer {
-  final bool enabled;
-  final bool isHovered;
-  final bool isPressed;
-
-  OudsButtonControlStateDeterminer({
-    required this.enabled,
-    this.isHovered = false,
-    this.isPressed = false,
-  });
-
-  /// Determines the current material state of the control.
-  OudsButtonControlState determineControlState() {
-    if (!enabled) return OudsButtonControlState.disabled;
-    if (isPressed) return OudsButtonControlState.pressed;
-    if (isHovered) return OudsButtonControlState.hovered;
-    return OudsButtonControlState.enabled;
   }
 }

--- a/ouds_core/lib/components/button/internal/button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/button_icon_modifier.dart
@@ -1,0 +1,155 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+import 'package:flutter/material.dart';
+import 'package:ouds_core/components/button/internal/button_loading_modifier.dart';
+import 'package:ouds_core/components/button/ouds_button.dart';
+import 'package:ouds_theme_contract/ouds_theme.dart';
+
+class OudsButtonIconModifier {
+  final BuildContext context;
+
+  OudsButtonIconModifier(this.context);
+
+  static Color getIconColor(BuildContext context, OudsButtonControlState states, OudsButtonHierarchy hierarchy, OudsButtonStyle? style) {
+    if (style == OudsButtonStyle.loading) {
+      return ButtonLoadingModifier.getColorToken(context, hierarchy);
+    }
+    print("states: $states");
+    switch (states) {
+      case OudsButtonControlState.enabled:
+        return _getEnabledIconColor(context, hierarchy);
+      case OudsButtonControlState.hovered:
+        return Colors.yellow;
+        return _getHoverIconColor(context, hierarchy);
+      case OudsButtonControlState.pressed:
+        return Colors.red;
+      //    return _getPressedIconColor(context, hierarchy);
+      case OudsButtonControlState.disabled:
+        return Colors.blue;
+      // return _getDisabledIconColor(context, hierarchy);
+    }
+  }
+
+  /// Color icon color based on button state and selection
+  static Color _getEnabledIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (hierarchy) {
+      case OudsButtonHierarchy.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongEnabled : theme.colorScheme(context).contentOnActionEnabled;
+      case OudsButtonHierarchy.brand:
+        return theme.componentsTokens(context).button.colorContentBrandEnabled;
+      case OudsButtonHierarchy.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalEnabled : theme.componentsTokens(context).button.colorContentMinimalEnabled;
+      case OudsButtonHierarchy.negative:
+        return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultEnabled : theme.componentsTokens(context).button.colorContentDefaultEnabled;
+    }
+  }
+
+  static Color _getHoverIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (hierarchy) {
+      case OudsButtonHierarchy.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongHover : theme.colorScheme(context).contentOnActionHover;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionHover;
+      case OudsButtonHierarchy.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalHover : theme.componentsTokens(context).button.colorContentMinimalHover;
+      case OudsButtonHierarchy.negative:
+        return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultHover : theme.componentsTokens(context).button.colorContentDefaultHover;
+    }
+  }
+
+  static Color _getPressedIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (hierarchy) {
+      case OudsButtonHierarchy.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongPressed : theme.colorScheme(context).contentOnActionPressed;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionPressed;
+      case OudsButtonHierarchy.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultPressed : theme.componentsTokens(context).button.colorContentDefaultPressed;
+      case OudsButtonHierarchy.negative:
+        return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultPressed : theme.componentsTokens(context).button.colorContentDefaultPressed;
+    }
+  }
+
+  static Color _getDisabledIconColor(BuildContext context, OudsButtonHierarchy hierarchy) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (hierarchy) {
+      case OudsButtonHierarchy.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongDisabled : theme.colorScheme(context).contentOnActionDisabled;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionDisabled;
+      case OudsButtonHierarchy.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalDisabled : theme.componentsTokens(context).button.colorContentMinimalDisabled;
+      case OudsButtonHierarchy.negative:
+        return theme.colorScheme(context).contentOnActionDisabled;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultDisabled : theme.componentsTokens(context).button.colorContentDefaultDisabled;
+    }
+  }
+
+  static double getIconSize(BuildContext context, OudsButtonLayout layout) {
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+    switch (layout) {
+      case OudsButtonLayout.iconOnly:
+        return buttonToken.sizeIconOnly;
+      case OudsButtonLayout.iconAndText:
+        return buttonToken.sizeIcon;
+      case OudsButtonLayout.textOnly:
+        return 0.0;
+    }
+  }
+}
+
+// TODO: create new file for this class
+
+/// Enum representing the state of the chip control.
+enum OudsButtonControlState {
+  enabled,
+  hovered,
+  pressed,
+  disabled,
+}
+
+/// A class that determines the state of the OudsChip
+class OudsButtonControlStateDeterminer {
+  final bool enabled;
+  final bool isHovered;
+  final bool isPressed;
+
+  OudsButtonControlStateDeterminer({
+    required this.enabled,
+    this.isHovered = false,
+    this.isPressed = false,
+  });
+
+  /// Determines the current material state of the control.
+  OudsButtonControlState determineControlState() {
+    if (!enabled) return OudsButtonControlState.disabled;
+    if (isPressed) return OudsButtonControlState.pressed;
+    if (isHovered) return OudsButtonControlState.hovered;
+    return OudsButtonControlState.enabled;
+  }
+}

--- a/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
@@ -48,6 +48,8 @@ class OudsButtonBackgroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongEnabled : theme.colorScheme(context).actionEnabled;
+      case OudsButtonHierarchy.brand:
+        return theme.componentsTokens(context).button.colorBgBrandEnabled;
       case OudsButtonHierarchy.minimal:
         return null;
       case OudsButtonHierarchy.negative:
@@ -63,6 +65,8 @@ class OudsButtonBackgroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongHover : theme.colorScheme(context).actionHover;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).actionHover;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).button.colorBgMinimalHover : theme.componentsTokens(context).button.colorBgMinimalHover;
       case OudsButtonHierarchy.negative:
@@ -78,6 +82,8 @@ class OudsButtonBackgroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongPressed : theme.colorScheme(context).actionPressed;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).actionPressed;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgMinimalPressed : theme.componentsTokens(context).button.colorBgMinimalPressed;
       case OudsButtonHierarchy.negative:
@@ -93,6 +99,8 @@ class OudsButtonBackgroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongDisabled : theme.colorScheme(context).actionDisabled;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).actionDisabled;
       case OudsButtonHierarchy.minimal:
         return null;
       case OudsButtonHierarchy.negative:

--- a/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
@@ -11,6 +11,7 @@
 //
 
 import 'package:flutter/material.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';

--- a/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
@@ -21,7 +21,7 @@ class OudsButtonBackgroundModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
-    bool isPressed,
+    OudsButtonControlState? buttonState,
   ) {
     return WidgetStateProperty.resolveWith<Color?>(
       (Set<WidgetState> states) {
@@ -29,7 +29,9 @@ class OudsButtonBackgroundModifier {
           return OudsButtonLoadingModifier.getBackgroundToken(context, hierarchy);
         }
 
-        if (states.contains(WidgetState.pressed) || isPressed) {
+        // Handles both Flutter's native pressed state and custom OudsButton state.
+        // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
+        if (states.contains(WidgetState.pressed) || (buttonState != null && buttonState == OudsButtonControlState.pressed)) {
           return _getPressedColor(context, hierarchy);
         } else if (states.contains(WidgetState.hovered)) {
           return _getHoverColor(context, hierarchy);

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -22,7 +22,6 @@ class OudsButtonBorderModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
-    //OudsButtonBorder? border,
   ) {
     return WidgetStateProperty.resolveWith<BorderSide?>(
       (Set<WidgetState> states) {

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -48,6 +48,8 @@ class OudsButtonBorderModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderStrongEnabled, width: theme.componentsTokens(context).button.borderWidthDefault) : BorderSide.none;
+      case OudsButtonHierarchy.brand:
+        return BorderSide.none;
       case OudsButtonHierarchy.minimal:
         return BorderSide.none;
       case OudsButtonHierarchy.negative:
@@ -74,6 +76,8 @@ class OudsButtonBorderModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderStrongHover, width: theme.componentsTokens(context).button.borderWidthDefaultInteraction) : BorderSide.none;
+      case OudsButtonHierarchy.brand:
+        return BorderSide.none;
       case OudsButtonHierarchy.minimal:
         return BorderSide.none;
       case OudsButtonHierarchy.negative:
@@ -90,6 +94,8 @@ class OudsButtonBorderModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderStrongPressed, width: theme.componentsTokens(context).button.borderWidthDefaultInteraction) : BorderSide.none;
+      case OudsButtonHierarchy.brand:
+        return BorderSide.none;
       case OudsButtonHierarchy.minimal:
         return BorderSide.none;
       case OudsButtonHierarchy.negative:
@@ -107,6 +113,8 @@ class OudsButtonBorderModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderStrongDisabled, width: theme.componentsTokens(context).button.borderWidthDefault) : BorderSide.none;
+      case OudsButtonHierarchy.brand:
+        return BorderSide.none;
       case OudsButtonHierarchy.minimal:
         return BorderSide.none;
       case OudsButtonHierarchy.negative:

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -60,16 +60,6 @@ class OudsButtonBorderModifier {
     }
   }
 
-  static BorderRadius _getEnabledBorderRadius(BuildContext context, OudsButtonBorder border) {
-    final button = OudsTheme.of(context).componentsTokens(context).button;
-    switch (border) {
-      case OudsButtonBorder.radiusRounded:
-        return BorderRadius.circular(button.borderRadiusRounded);
-      default:
-        return BorderRadius.circular(button.borderRadiusDefault);
-    }
-  }
-
   static BorderSide _getHoverBorderColor(BuildContext context, OudsButtonHierarchy hierarchy) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -13,7 +13,6 @@
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
-import 'package:ouds_theme_contract/config/component/ouds_button_config.dart';
 import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -23,6 +23,7 @@ class OudsButtonBorderModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
+    //OudsButtonBorder? border,
   ) {
     return WidgetStateProperty.resolveWith<BorderSide?>(
       (Set<WidgetState> states) {
@@ -54,6 +55,16 @@ class OudsButtonBorderModifier {
       default:
         return BorderSide(
             color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultEnabled : theme.componentsTokens(context).button.colorBorderDefaultEnabled, width: theme.componentsTokens(context).button.borderWidthDefault);
+    }
+  }
+
+  static BorderRadius _getEnabledBorderRadius(BuildContext context, OudsButtonBorder border) {
+    final button = OudsTheme.of(context).componentsTokens(context).button;
+    switch (border) {
+      case OudsButtonBorder.radiusRounded:
+        return BorderRadius.circular(button.borderRadiusRounded);
+      default:
+        return BorderRadius.circular(button.borderRadiusDefault);
     }
   }
 

--- a/ouds_core/lib/components/button/internal/ouds_button_control_state.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_control_state.dart
@@ -1,0 +1,45 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+/// Enum representing the different possible states of an Ouds button.
+enum OudsButtonControlState {
+  enabled, // The button is enabled and interactive.
+  hovered, // The cursor is over the button.
+  pressed, // The button is being pressed.
+  disabled, // The button is disabled and non-interactive.
+}
+
+/// This class used only for icon button.
+/// Class that determines the current state of an Ouds button based on its properties.
+class OudsButtonControlStateDeterminer {
+  final bool enabled;
+  final bool isHovered;
+  final bool isPressed;
+
+  /// Constructor to initialize the button state.
+  /// [enabled] is required, [isHovered] and [isPressed] default to false.
+  OudsButtonControlStateDeterminer({
+    required this.enabled,
+    this.isHovered = false,
+    this.isPressed = false,
+  });
+
+  /// Method that determines the current state of the button based on its properties.
+  /// Returns a value from the OudsButtonControlState enum.
+  OudsButtonControlState determineControlState() {
+    if (!enabled) return OudsButtonControlState.disabled;
+    if (isPressed) return OudsButtonControlState.pressed;
+    if (isHovered) return OudsButtonControlState.hovered;
+    return OudsButtonControlState.enabled;
+  }
+}

--- a/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
@@ -11,6 +11,7 @@
 //
 
 import 'package:flutter/material.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';

--- a/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
@@ -21,7 +21,7 @@ class OudsButtonForegroundModifier {
     BuildContext context,
     OudsButtonHierarchy hierarchy,
     OudsButtonStyle? style,
-    bool isPressed,
+    OudsButtonControlState? buttonState,
   ) {
     return WidgetStateProperty.resolveWith<Color?>(
       (Set<WidgetState> states) {
@@ -29,7 +29,9 @@ class OudsButtonForegroundModifier {
           return OudsButtonLoadingModifier.getColorToken(context, hierarchy);
         }
 
-        if (states.contains(WidgetState.pressed) || isPressed) {
+        // Handles both Flutter's native pressed state and custom OudsButton state.
+        // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
+        if (states.contains(WidgetState.pressed) || (buttonState != null && buttonState == OudsButtonControlState.pressed)) {
           return _getPressedForegroundColor(context, hierarchy);
         } else if (states.contains(WidgetState.hovered)) {
           return _getHoverForegroundColor(context, hierarchy);

--- a/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
@@ -47,6 +47,8 @@ class OudsButtonForegroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongEnabled : theme.colorScheme(context).contentOnActionEnabled;
+      case OudsButtonHierarchy.brand:
+        return theme.componentsTokens(context).button.colorContentBrandEnabled;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalEnabled : theme.componentsTokens(context).button.colorContentMinimalEnabled;
       case OudsButtonHierarchy.negative:
@@ -62,6 +64,8 @@ class OudsButtonForegroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongHover : theme.colorScheme(context).contentOnActionHover;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionHover;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalHover : theme.componentsTokens(context).button.colorContentMinimalHover;
       case OudsButtonHierarchy.negative:
@@ -77,6 +81,8 @@ class OudsButtonForegroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongPressed : theme.colorScheme(context).contentOnActionPressed;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionPressed;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultPressed : theme.componentsTokens(context).button.colorContentDefaultPressed;
       case OudsButtonHierarchy.negative:
@@ -92,6 +98,8 @@ class OudsButtonForegroundModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongDisabled : theme.colorScheme(context).contentOnActionDisabled;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionDisabled;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalDisabled : theme.componentsTokens(context).button.colorContentMinimalDisabled;
       case OudsButtonHierarchy.negative:

--- a/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
@@ -12,8 +12,8 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:ouds_core/components/button/internal/button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
@@ -28,7 +28,7 @@ class OudsButtonIconModifier {
   static Color getIconColor(BuildContext context, OudsButtonControlState states, OudsButtonHierarchy hierarchy, OudsButtonStyle? style) {
     if (style == OudsButtonStyle.loading) {
       // If the button is in loading style, get the loading color token.
-      return ButtonLoadingModifier.getColorToken(context, hierarchy);
+      return OudsButtonLoadingModifier.getColorToken(context, hierarchy);
     }
     // Determine icon color based on the current control state.
     switch (states) {

--- a/ouds_core/lib/components/button/internal/ouds_button_loading_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_loading_modifier.dart
@@ -33,6 +33,8 @@ class OudsButtonLoadingModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongLoading : theme.colorScheme(context).contentOnActionLoading;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).contentOnActionLoading;
       case OudsButtonHierarchy.minimal:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalLoading : theme.componentsTokens(context).button.colorContentMinimalLoading;
       case OudsButtonHierarchy.negative:
@@ -48,6 +50,8 @@ class OudsButtonLoadingModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongLoading : theme.colorScheme(context).actionLoading;
+      case OudsButtonHierarchy.brand:
+        return theme.colorScheme(context).actionLoading;
       case OudsButtonHierarchy.minimal:
         return null;
       case OudsButtonHierarchy.negative:
@@ -63,6 +67,8 @@ class OudsButtonLoadingModifier {
     switch (hierarchy) {
       case OudsButtonHierarchy.strong:
         return onColoredSurface ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderStrongLoading, width: theme.componentsTokens(context).button.borderWidthDefaultInteraction) : BorderSide.none;
+      case OudsButtonHierarchy.brand:
+        return BorderSide.none;
       case OudsButtonHierarchy.minimal:
         return BorderSide.none;
       case OudsButtonHierarchy.negative:

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -23,6 +23,7 @@ class OudsButtonStyleModifier {
     BuildContext context, {
     required OudsButtonHierarchy hierarchy,
     required OudsButtonLayout layout,
+    OudsButtonBorder? border,
     OudsButtonStyle? style,
     required bool isPressed,
   }) {
@@ -52,7 +53,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: OudsButtonBorderModifier.getBorderRadius(context),
+          borderRadius: _getEnabledBorderRadius(context, border ?? OudsButtonBorder.radiusDefault),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
@@ -63,5 +64,16 @@ class OudsButtonStyleModifier {
       ),
       animationDuration: Duration.zero,
     );
+  }
+
+  static BorderRadius _getEnabledBorderRadius(BuildContext context, OudsButtonBorder border) {
+    final button = OudsTheme.of(context).componentsTokens(context).button;
+    print("border : ${border.toString()}");
+    switch (border) {
+      case OudsButtonBorder.radiusRounded:
+        return BorderRadius.circular(button.borderRadiusRounded);
+      case OudsButtonBorder.radiusDefault:
+        return BorderRadius.circular(button.borderRadiusDefault);
+    }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -23,7 +23,7 @@ class OudsButtonStyleModifier {
     BuildContext context, {
     required OudsButtonHierarchy hierarchy,
     required OudsButtonLayout layout,
-    OudsButtonBorder? border,
+    bool? border,
     OudsButtonStyle? style,
     required bool isPressed,
   }) {
@@ -36,12 +36,12 @@ class OudsButtonStyleModifier {
       iconSize = 0.0;
     }
     return ButtonStyle(
-      backgroundColor: OudsButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, isPressed),
-      foregroundColor: OudsButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
-      iconColor: OudsButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
+      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, isPressed),
+      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
+      //iconColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
       splashFactory: NoSplash.splashFactory,
       overlayColor: WidgetStateProperty.all(Colors.transparent),
-      iconSize: WidgetStateProperty.all<double>(iconSize),
+      //iconSize: WidgetStateProperty.all<double>(iconSize),
       textStyle: WidgetStateProperty.all<TextStyle>(
         TextStyle(
             fontSize: OudsTheme.of(context).fontTokens.sizeLabelLarge,
@@ -53,7 +53,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: _getEnabledBorderRadius(context, border ?? OudsButtonBorder.radiusDefault),
+          borderRadius: _getEnabledBorderRadius(context, border),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
@@ -66,13 +66,13 @@ class OudsButtonStyleModifier {
     );
   }
 
-  static BorderRadius _getEnabledBorderRadius(BuildContext context, OudsButtonBorder border) {
+  static BorderRadius _getEnabledBorderRadius(BuildContext context, bool? border) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
     print("border : ${border.toString()}");
-    switch (border) {
-      case OudsButtonBorder.radiusRounded:
+    switch (border!) {
+      case true:
         return BorderRadius.circular(button.borderRadiusRounded);
-      case OudsButtonBorder.radiusDefault:
+      case false:
         return BorderRadius.circular(button.borderRadiusDefault);
     }
   }

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -43,7 +43,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: _getEnabledBorderRadius(context, border),
+          borderRadius: _getBorderRadius(context, border),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
@@ -56,7 +56,9 @@ class OudsButtonStyleModifier {
     );
   }
 
-  static BorderRadius _getEnabledBorderRadius(BuildContext context, bool? border) {
+  /// Static method to get the border radius for a button based on the border parameter.
+  /// Returns a [BorderRadius] object with the appropriate radius value.
+  static BorderRadius _getBorderRadius(BuildContext context, bool? border) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
     switch (border!) {
       case true:

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -13,6 +13,7 @@
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_background_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_border_modifier.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_foreground_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_padding_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
@@ -28,8 +29,8 @@ class OudsButtonStyleModifier {
     OudsButtonControlState? buttonState,
   }) {
     return ButtonStyle(
-      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, buttonState),
-      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, buttonState),
+      backgroundColor: OudsButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, buttonState),
+      foregroundColor: OudsButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, buttonState),
       splashFactory: NoSplash.splashFactory,
       overlayColor: WidgetStateProperty.all(Colors.transparent),
       textStyle: WidgetStateProperty.all<TextStyle>(
@@ -43,7 +44,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: ButtonBorderModifier.getBorderRadius(context, border),
+          borderRadius: OudsButtonBorderModifier.getBorderRadius(context),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -25,11 +25,11 @@ class OudsButtonStyleModifier {
     required OudsButtonLayout layout,
     bool? border,
     OudsButtonStyle? style,
-    required bool isPressed,
+    OudsButtonControlState? buttonState,
   }) {
     return ButtonStyle(
-      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, isPressed),
-      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
+      backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, buttonState),
+      foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, buttonState),
       splashFactory: NoSplash.splashFactory,
       overlayColor: WidgetStateProperty.all(Colors.transparent),
       textStyle: WidgetStateProperty.all<TextStyle>(
@@ -43,7 +43,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: _getBorderRadius(context, border),
+          borderRadius: ButtonBorderModifier.getBorderRadius(context, border),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
@@ -54,17 +54,5 @@ class OudsButtonStyleModifier {
       ),
       animationDuration: Duration.zero,
     );
-  }
-
-  /// Static method to get the border radius for a button based on the border parameter.
-  /// Returns a [BorderRadius] object with the appropriate radius value.
-  static BorderRadius _getBorderRadius(BuildContext context, bool? border) {
-    final button = OudsTheme.of(context).componentsTokens(context).button;
-    switch (border!) {
-      case true:
-        return BorderRadius.circular(button.borderRadiusRounded);
-      case false:
-        return BorderRadius.circular(button.borderRadiusDefault);
-    }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -27,21 +27,11 @@ class OudsButtonStyleModifier {
     OudsButtonStyle? style,
     required bool isPressed,
   }) {
-    double iconSize;
-    if (layout == OudsButtonLayout.iconOnly) {
-      iconSize = OudsTheme.of(context).componentsTokens(context).button.sizeIconOnly;
-    } else if (layout == OudsButtonLayout.iconAndText) {
-      iconSize = OudsTheme.of(context).componentsTokens(context).button.sizeIcon;
-    } else {
-      iconSize = 0.0;
-    }
     return ButtonStyle(
       backgroundColor: ButtonBackgroundModifier.resolveBackgroundColor(context, hierarchy, style, isPressed),
       foregroundColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
-      //iconColor: ButtonForegroundModifier.resolveForegroundColor(context, hierarchy, style, isPressed),
       splashFactory: NoSplash.splashFactory,
       overlayColor: WidgetStateProperty.all(Colors.transparent),
-      //iconSize: WidgetStateProperty.all<double>(iconSize),
       textStyle: WidgetStateProperty.all<TextStyle>(
         TextStyle(
             fontSize: OudsTheme.of(context).fontTokens.sizeLabelLarge,
@@ -68,7 +58,6 @@ class OudsButtonStyleModifier {
 
   static BorderRadius _getEnabledBorderRadius(BuildContext context, bool? border) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
-    print("border : ${border.toString()}");
     switch (border!) {
       case true:
         return BorderRadius.circular(button.borderRadiusRounded);

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -39,6 +39,14 @@ enum OudsButtonLayout {
   iconOnly;
 }
 
+///The [OudsButtonLayout] defines the layout of the button’s content.
+///
+/// This enum controls whether the button displays text, an icon, or both.
+enum OudsButtonBorder {
+  radiusDefault,
+  radiusRounded;
+}
+
 /// [OUDS Button design guidelines](https://unified-design-system.orange.com/472794e18/p/48a788-button)
 ///
 /// Buttons are interactive elements designed to trigger specific actions or events when tapped by a user.
@@ -81,6 +89,7 @@ class OudsButton extends StatefulWidget {
   final String? label;
   final Widget? icon;
   final VoidCallback? onPressed;
+  final OudsButtonBorder? border;
   final OudsButtonStyle style;
   final OudsButtonHierarchy hierarchy;
 
@@ -89,6 +98,7 @@ class OudsButton extends StatefulWidget {
     this.label,
     this.icon,
     this.onPressed,
+    this.border = OudsButtonBorder.radiusDefault,
     required this.style,
     required this.hierarchy,
   });

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -17,6 +17,7 @@ import 'package:ouds_core/components/button/internal/ouds_button_icon_modifier.d
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// The [OudsButtonHierarchy] enum defines the visual importance of the button within the UI.
@@ -41,14 +42,6 @@ enum OudsButtonLayout {
   textOnly,
   iconAndText,
   iconOnly;
-}
-
-///The [OudsButtonBorder] defines the border of the button’s content.
-///
-/// This enum controls  the border of the button.
-enum OudsButtonBorder {
-  radiusDefault,
-  radiusRounded;
 }
 
 /// [OUDS Button design guidelines](https://unified-design-system.orange.com/472794e18/p/48a788-button)
@@ -125,7 +118,7 @@ class OudsButton extends StatefulWidget {
 
 class _OudsButtonState extends State<OudsButton> {
   // TODO: changed with theme variable rounded
-  final isButtonRounded = true;
+  //final isButtonRounded = true;
 
   // Tracks hover and press states manually for custom SVG icon rendering.
   //
@@ -186,7 +179,7 @@ class _OudsButtonState extends State<OudsButton> {
 
   Widget _buildButtonIconAndText(BuildContext context, OudsButtonControlState buttonState) {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
-
+    final isButtonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return MouseRegion(
@@ -269,6 +262,8 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconOnly(BuildContext context, OudsButtonControlState buttonState) {
+    final isButtonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
+
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return MouseRegion(
@@ -315,6 +310,7 @@ class _OudsButtonState extends State<OudsButton> {
 
   Widget _buildButtonTextOnly(BuildContext context) {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+    final isButtonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
 
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -11,6 +11,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_icon_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
@@ -186,30 +189,39 @@ class _OudsButtonState extends State<OudsButton> {
 
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
-        return ClipRRect(
-          borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
-          child: OutlinedButton(
-            onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Row(
-                  mainAxisSize: MainAxisSize.min,
+        return MouseRegion(
+          onEnter: (_) => setState(() => _isHovered = true),
+          onExit: (_) => setState(() => _isHovered = false),
+          child: GestureDetector(
+            onTapDown: (_) => setState(() => _isPressed = true),
+            onTapUp: (_) => setState(() => _isPressed = false),
+            onTapCancel: () => setState(() => _isPressed = false),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
+              child: OutlinedButton(
+                onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
+                style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, buttonState: buttonState, border: isButtonRounded),
+                child: Stack(
+                  alignment: Alignment.center,
                   children: [
-                    widget.icon!,
-                    SizedBox(
-                      width: buttonToken.spaceColumnGapIcon,
-                    ),
-                    Flexible(
-                      child: Text(
-                        widget.label ?? "",
-                        textAlign: TextAlign.center,
-                      ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _buildIcon(context, widget.icon!, widget.hierarchy, widget.layout, widget.style, buttonState),
+                        SizedBox(
+                          width: buttonToken.spaceColumnGapIcon,
+                        ),
+                        Flexible(
+                          child: Text(
+                            widget.label ?? "",
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ],
                     ),
                   ],
                 ),
-              ],
+              ),
             ),
           ),
         );
@@ -220,7 +232,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, buttonState: buttonState, border: isButtonRounded),
               child: Stack(
                 alignment: Alignment.center,
                 children: [
@@ -259,14 +271,23 @@ class _OudsButtonState extends State<OudsButton> {
   Widget _buildButtonIconOnly(BuildContext context, OudsButtonControlState buttonState) {
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
-        return Semantics(
-          label: OudsLocalizations.of(context)?.core_button_icon_only_a11y,
-          button: true,
-          child: ExcludeSemantics(
-            child: IconButton(
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
-              onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-              icon: _buildIcon(context, widget.icon!, widget.hierarchy, widget.layout, widget.style, buttonState),
+        return MouseRegion(
+          onEnter: (_) => setState(() => _isHovered = true),
+          onExit: (_) => setState(() => _isHovered = false),
+          child: GestureDetector(
+            onTapDown: (_) => setState(() => _isPressed = true),
+            onTapUp: (_) => setState(() => _isPressed = false),
+            onTapCancel: () => setState(() => _isPressed = false),
+            child: Semantics(
+              label: OudsLocalizations.of(context)?.core_button_icon_only_a11y,
+              button: true,
+              child: ExcludeSemantics(
+                child: IconButton(
+                  style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, buttonState: buttonState, border: isButtonRounded),
+                  onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
+                  icon: _buildIcon(context, widget.icon!, widget.hierarchy, widget.layout, widget.style, buttonState),
+                ),
+              ),
             ),
           ),
         );
@@ -276,7 +297,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: IconButton(
             onPressed: null,
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, buttonState: buttonState, border: isButtonRounded),
             icon: Stack(
               alignment: Alignment.center,
               children: [
@@ -300,7 +321,7 @@ class _OudsButtonState extends State<OudsButton> {
         return ClipRRect(
           borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
           child: OutlinedButton(
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, border: isButtonRounded),
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             child: Text(
               widget.label ?? "",
@@ -315,7 +336,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, border: isButtonRounded),
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -90,7 +90,6 @@ class OudsButton extends StatefulWidget {
   final String? label;
   final String? icon;
   final VoidCallback? onPressed;
-  //final OudsButtonBorder? border;
   final OudsButtonStyle style;
   final OudsButtonHierarchy hierarchy;
 
@@ -99,7 +98,6 @@ class OudsButton extends StatefulWidget {
     this.label,
     this.icon,
     this.onPressed,
-    //this.border = OudsButtonBorder.radiusDefault,
     required this.style,
     required this.hierarchy,
   });

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -88,7 +88,7 @@ enum OudsButtonBorder {
 ///
 class OudsButton extends StatefulWidget {
   final String? label;
-  final Widget? icon;
+  final String? icon;
   final VoidCallback? onPressed;
   //final OudsButtonBorder? border;
   final OudsButtonStyle style;
@@ -110,7 +110,7 @@ class OudsButton extends StatefulWidget {
   /// Property that detects and returns the button layout based on the provided elements (text and/or icon)
   OudsButtonLayout get layout => _detectLayout(label, icon);
 
-  static OudsButtonLayout _detectLayout(String? label, Widget? icon) {
+  static OudsButtonLayout _detectLayout(String? label, String? icon) {
     if (label != null && icon != null) {
       return OudsButtonLayout.iconAndText;
     } else if (label != null) {
@@ -123,11 +123,14 @@ class OudsButton extends StatefulWidget {
 }
 
 class _OudsButtonState extends State<OudsButton> {
-  bool _isPressed = false;
+  // TODO: changed with theme variable rounded
   final isButtonRounded = false;
-
+  // ------------------------------------------
   // Added to improve visual rendering fluidity by allowing Flutter
   // to complete the current frame before executing the onPressed callback.
+  bool _isHovered = false;
+  bool _isPressed = false;
+
   void _handlePressed(VoidCallback? callback) {
     setState(() {
       _isPressed = true;
@@ -145,6 +148,13 @@ class _OudsButtonState extends State<OudsButton> {
 
   @override
   Widget build(BuildContext context) {
+    final buttonStateDeterminer = OudsButtonControlStateDeterminer(
+      enabled: widget.onPressed != null,
+      isPressed: _isPressed,
+      isHovered: _isHovered,
+    );
+    final buttonState = buttonStateDeterminer.determineControlState();
+
     try {
       if (widget.hierarchy == OudsButtonHierarchy.negative && OudsTheme.isOnColoredSurfaceOf(context)) {
         // Throw an IllegalStateException
@@ -155,15 +165,15 @@ class _OudsButtonState extends State<OudsButton> {
     }
     switch (widget.layout) {
       case OudsButtonLayout.iconOnly:
-        return _buildButtonIconOnly(context);
+        return _buildButtonIconOnly(context, buttonState);
       case OudsButtonLayout.iconAndText:
-        return _buildButtonIconAndText(context);
+        return _buildButtonIconAndText(context, buttonState);
       case OudsButtonLayout.textOnly:
         return _buildButtonTextOnly(context);
     }
   }
 
-  Widget _buildButtonIconAndText(BuildContext context) {
+  Widget _buildButtonIconAndText(BuildContext context, OudsButtonControlState buttonState) {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
 
     switch (widget.style) {
@@ -238,7 +248,7 @@ class _OudsButtonState extends State<OudsButton> {
     }
   }
 
-  Widget _buildButtonIconOnly(BuildContext context) {
+  Widget _buildButtonIconOnly(BuildContext context, OudsButtonControlState buttonState) {
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return Semantics(
@@ -248,7 +258,7 @@ class _OudsButtonState extends State<OudsButton> {
             child: IconButton(
               style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
               onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-              icon: widget.icon!,
+              icon: _buildIcon(context, widget.icon!, widget.hierarchy, widget.layout, widget.style, buttonState),
             ),
           ),
         );
@@ -327,20 +337,21 @@ class _OudsButtonState extends State<OudsButton> {
     );
   }
 
-  static Widget buildIcon(
+  static Widget _buildIcon(
     BuildContext context,
     String assetName,
-    //OudsChipControlState controlItemState,
+    final OudsButtonHierarchy hierarchy,
+    final OudsButtonLayout layout,
+    final OudsButtonStyle? style,
+    final OudsButtonControlState buttonState,
   ) {
-    //final controlIconModifier = OudsChipControlIconColorModifier(context);
-    final button = OudsTheme.of(context).componentsTokens(context).button;
     return SvgPicture.asset(
       assetName,
       fit: BoxFit.contain,
-      width: button.sizeIcon,
-      height: button.sizeIcon,
+      width: OudsButtonIconModifier.getIconSize(context, layout),
+      height: OudsButtonIconModifier.getIconSize(context, layout),
       colorFilter: ColorFilter.mode(
-        OudsTheme.of(context).componentsTokens(context).button.colorContentDefaultEnabled,
+        OudsButtonIconModifier.getIconColor(context, buttonState, hierarchy, style),
         BlendMode.srcIn,
       ),
     );

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -20,6 +20,7 @@ import 'package:ouds_theme_contract/ouds_theme.dart';
 enum OudsButtonHierarchy {
   defaultHierarchy,
   strong,
+  brand,
   minimal,
   negative,
 }

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -40,9 +40,9 @@ enum OudsButtonLayout {
   iconOnly;
 }
 
-///The [OudsButtonLayout] defines the layout of the button’s content.
+///The [OudsButtonBorder] defines the border of the button’s content.
 ///
-/// This enum controls whether the button displays text, an icon, or both.
+/// This enum controls  the border of the button.
 enum OudsButtonBorder {
   radiusDefault,
   radiusRounded;
@@ -90,7 +90,7 @@ class OudsButton extends StatefulWidget {
   final String? label;
   final Widget? icon;
   final VoidCallback? onPressed;
-  final OudsButtonBorder? border;
+  //final OudsButtonBorder? border;
   final OudsButtonStyle style;
   final OudsButtonHierarchy hierarchy;
 
@@ -99,7 +99,7 @@ class OudsButton extends StatefulWidget {
     this.label,
     this.icon,
     this.onPressed,
-    this.border = OudsButtonBorder.radiusDefault,
+    //this.border = OudsButtonBorder.radiusDefault,
     required this.style,
     required this.hierarchy,
   });
@@ -124,6 +124,7 @@ class OudsButton extends StatefulWidget {
 
 class _OudsButtonState extends State<OudsButton> {
   bool _isPressed = false;
+  final isButtonRounded = false;
 
   // Added to improve visual rendering fluidity by allowing Flutter
   // to complete the current frame before executing the onPressed callback.
@@ -163,11 +164,12 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconAndText(BuildContext context) {
-    final button = OudsTheme.of(context).componentsTokens(context).button;
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
-          borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
+          borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
           child: OutlinedButton(
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
@@ -179,7 +181,7 @@ class _OudsButtonState extends State<OudsButton> {
                   children: [
                     widget.icon!,
                     SizedBox(
-                      width: OudsTheme.of(context).componentsTokens(context).button.spaceColumnGapIcon,
+                      width: buttonToken.spaceColumnGapIcon,
                     ),
                     Flexible(
                       child: Text(
@@ -209,10 +211,10 @@ class _OudsButtonState extends State<OudsButton> {
                     children: [
                       Icon(
                         null,
-                        size: OudsTheme.of(context).componentsTokens(context).button.sizeIcon,
+                        size: buttonToken.sizeIcon,
                       ),
                       SizedBox(
-                        width: OudsTheme.of(context).componentsTokens(context).button.spaceColumnGapIcon,
+                        width: buttonToken.spaceColumnGapIcon,
                       ),
                       Flexible(
                         child: Text(
@@ -225,7 +227,7 @@ class _OudsButtonState extends State<OudsButton> {
                     ],
                   ),
                   Padding(
-                    padding: EdgeInsetsDirectional.only(start: OudsTheme.of(context).componentsTokens(context).button.spaceColumnGapIcon),
+                    padding: EdgeInsetsDirectional.only(start: buttonToken.spaceColumnGapIcon),
                     child: _buildLoadingIndicator(context),
                   ),
                 ],
@@ -273,10 +275,12 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonTextOnly(BuildContext context) {
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
-          borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
+          borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
           child: OutlinedButton(
             style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
@@ -319,6 +323,25 @@ class _OudsButtonState extends State<OudsButton> {
       child: CircularProgressIndicator(
         color: OudsButtonLoadingModifier.getColorToken(context, widget.hierarchy),
         strokeWidth: 3,
+      ),
+    );
+  }
+
+  static Widget buildIcon(
+    BuildContext context,
+    String assetName,
+    //OudsChipControlState controlItemState,
+  ) {
+    //final controlIconModifier = OudsChipControlIconColorModifier(context);
+    final button = OudsTheme.of(context).componentsTokens(context).button;
+    return SvgPicture.asset(
+      assetName,
+      fit: BoxFit.contain,
+      width: button.sizeIcon,
+      height: button.sizeIcon,
+      colorFilter: ColorFilter.mode(
+        OudsTheme.of(context).componentsTokens(context).button.colorContentDefaultEnabled,
+        BlendMode.srcIn,
       ),
     );
   }

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -122,10 +122,17 @@ class OudsButton extends StatefulWidget {
 
 class _OudsButtonState extends State<OudsButton> {
   // TODO: changed with theme variable rounded
-  final isButtonRounded = false;
-  // ------------------------------------------
-  // Added to improve visual rendering fluidity by allowing Flutter
-  // to complete the current frame before executing the onPressed callback.
+  final isButtonRounded = true;
+
+  // Tracks hover and press states manually for custom SVG icon rendering.
+  //
+  // Flutter’s [ButtonStyle] uses [WidgetStateProperty] for styling based on
+  // states like hovered, focused, or pressed. However, this does not apply
+  // directly to SVGs via [colorFilter].
+  //
+  // To support dynamic color changes on SVG icons, we track interaction
+  // states manually using [MouseRegion] and [GestureDetector], enabling us to
+  // update the icon style accordingly.
   bool _isHovered = false;
   bool _isPressed = false;
 
@@ -146,6 +153,9 @@ class _OudsButtonState extends State<OudsButton> {
 
   @override
   Widget build(BuildContext context) {
+    // Determines the local visual state of the button (hovered, pressed, etc.)
+    // using internal flags managed via a [MouseRegion] and gesture listeners.
+    // This state is used to compute dynamic styling (e.g., background color).
     final buttonStateDeterminer = OudsButtonControlStateDeterminer(
       enabled: widget.onPressed != null,
       isPressed: _isPressed,
@@ -272,7 +282,7 @@ class _OudsButtonState extends State<OudsButton> {
               children: [
                 Opacity(
                   opacity: OudsTheme.of(context).opacityTokens.invisible,
-                  child: Icon(Icons.favorite_border),
+                  child: _buildIcon(context, widget.icon!, widget.hierarchy, widget.layout, widget.style, buttonState),
                 ),
                 _buildLoadingIndicator(context),
               ],

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -163,6 +163,7 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconAndText(BuildContext context) {
+    final button = OudsTheme.of(context).componentsTokens(context).button;
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(

--- a/ouds_theme_contract/lib/theme/scheme/color/ouds_color_scheme.dart
+++ b/ouds_theme_contract/lib/theme/scheme/color/ouds_color_scheme.dart
@@ -160,7 +160,7 @@ class OudsColorScheme {
 
   Color get contentOnBrandPrimary => isDarkTheme ? colorTokens.contentColorTokens.contentOnBrandPrimaryDark : colorTokens.contentColorTokens.contentOnBrandPrimaryLight;
 
-  Color get contentOnBrandSecondary => isDarkTheme ? colorTokens.contentColorTokens.contentBrandSecondaryDark : colorTokens.contentColorTokens.contentBrandSecondaryLight;
+  Color get contentOnBrandSecondary => isDarkTheme ? colorTokens.contentColorTokens.contentOnBrandSecondaryDark : colorTokens.contentColorTokens.contentOnBrandSecondaryLight;
 
   Color get contentOnBrandTertiary => isDarkTheme ? colorTokens.contentColorTokens.contentOnBrandTertiaryDark : colorTokens.contentColorTokens.contentOnBrandTertiaryLight;
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#299 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test (dark mode, RTL, landscape display, tablet)
- [ ] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [ ] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [ ] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
