### PR TITLE
feat: refactor themeconfigmodel to use per component configuration classes button tag textinput

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [DemoApp][Library] Integration of Sosh theme ([#262](https://github.com/Orange-OpenSource/ouds-flutter/issues/262))
 
 ### Changed
+- [DemoApp][Library] Refactor with custom configuration Rounded `Button`, `Tag` and `TextInput` ([#299](-https://github.com/Orange-OpenSource/ouds-flutter/issues/299))
 - [Library] Refactor `Chip` and `Button` classes name ([#298](-https://github.com/Orange-OpenSource/ouds-flutter/issues/298))
 - [DemoApp] Include Design Component version in Design Toolbox App ([#240](https://github.com/Orange-OpenSource/ouds-flutter/issues/240))
 - [DemoApp] Replace components illustrations by the components themselves ([#247](https://github.com/Orange-OpenSource/ouds-flutter/issues/247))

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -59,9 +59,9 @@ class _OudsApplicationState extends State<OudsApplication> {
                     ? TextDirection.rtl // If the language is RTL, use TextDirection.rtl
                     : TextDirection.ltr, // Otherwise, use TextDirection.ltr
                 child: OudsThemeConfigModel(
-                  button: OudsButtonConfig(rounded: OudsButtonConfigBorder.radiusRounded),
-                  tag: OudsTagConfig(rounded: OudsTagConfigBorder.radiusDefault),
-                  textInput: OudsTextInputConfig(rounded: OudsTextInputConfigBorder.radiusDefault),
+                  button: OudsButtonConfig(rounded: true),
+                  tag: OudsTagConfig(rounded: false),
+                  textInput: OudsTextInputConfig(rounded: false),
                   child: OudsTheme(
                     themeContract: themeController.currentTheme,
                     themeMode: themeController.themeMode,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -29,9 +29,9 @@ import 'package:provider/provider.dart';
 void main() {
   runApp(
     OudsThemeConfigModel(
-      button: OudsButtonConfig(rounded: true),
-      tag: OudsTagConfig(rounded: false),
-      textInput: OudsTextInputConfig(rounded: true),
+      button: OudsButtonConfig(rounded: OudsButtonConfigBorder.radiusRounded),
+      tag: OudsTagConfig(rounded: OudsTagConfigBorder.radiusDefault),
+      textInput: OudsTextInputConfig(rounded: OudsTextInputConfigBorder.radiusDefault),
       child: const OudsApplication(),
     ),
   );
@@ -65,11 +65,16 @@ class _OudsApplicationState extends State<OudsApplication> {
                 textDirection: Directionality.of(context) == TextDirection.rtl
                     ? TextDirection.rtl // If the language is RTL, use TextDirection.rtl
                     : TextDirection.ltr, // Otherwise, use TextDirection.ltr
-                child: OudsTheme(
-                  themeContract: themeController.currentTheme,
-                  themeMode: themeController.themeMode,
-                  onColoredSurface: themeController.onColoredSurface,
-                  child: child ?? Container(),
+                child: OudsThemeConfigModel(
+                  button: OudsButtonConfig(rounded: OudsButtonConfigBorder.radiusRounded),
+                  tag: OudsTagConfig(rounded: OudsTagConfigBorder.radiusDefault),
+                  textInput: OudsTextInputConfig(rounded: OudsTextInputConfigBorder.radiusDefault),
+                  child: OudsTheme(
+                    themeContract: themeController.currentTheme,
+                    themeMode: themeController.themeMode,
+                    onColoredSurface: themeController.onColoredSurface,
+                    child: child ?? Container(),
+                  ),
                 ),
               );
             },

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -19,11 +19,22 @@ import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
 import 'package:ouds_flutter_demo/l10n/gen/ouds_flutter_app_localizations.dart';
 import 'package:ouds_flutter_demo/ui/main_screen.dart';
 import 'package:ouds_flutter_demo/ui/theme/theme_controller.dart';
+import 'package:ouds_theme_contract/config/component/ouds_button_config.dart';
+import 'package:ouds_theme_contract/config/component/ouds_tag_config.dart';
+import 'package:ouds_theme_contract/config/component/ouds_text_input_config.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
 
 void main() {
-  runApp(OudsApplication());
+  runApp(
+    OudsThemeConfigModel(
+      button: OudsButtonConfig(rounded: true),
+      tag: OudsTagConfig(rounded: false),
+      textInput: OudsTextInputConfig(rounded: true),
+      child: const OudsApplication(),
+    ),
+  );
 }
 
 class OudsApplication extends StatefulWidget {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -27,14 +27,7 @@ import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
 
 void main() {
-  runApp(
-    OudsThemeConfigModel(
-      button: OudsButtonConfig(rounded: OudsButtonConfigBorder.radiusRounded),
-      tag: OudsTagConfig(rounded: OudsTagConfigBorder.radiusDefault),
-      textInput: OudsTextInputConfig(rounded: OudsTextInputConfigBorder.radiusDefault),
-      child: const OudsApplication(),
-    ),
-  );
+  runApp(const OudsApplication());
 }
 
 class OudsApplication extends StatefulWidget {

--- a/app/lib/ui/theme/theme_controller.dart
+++ b/app/lib/ui/theme/theme_controller.dart
@@ -11,6 +11,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme_contract.dart';
 import 'package:ouds_theme_orange/orange_theme.dart';
 import 'package:ouds_theme_sosh/ouds_theme_sosh.dart';
@@ -19,6 +20,7 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
   ThemeMode _themeMode = ThemeMode.system;
   OudsThemeContract _currentTheme = OrangeTheme();
   bool _onColoredSurface = false;
+  bool _onBorderRadiusState = false;
 
   /// Getter to access the current theme
   OudsThemeContract get currentTheme => _currentTheme;
@@ -28,6 +30,9 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Getter to know if we are on a colored surface
   bool get onColoredSurface => _onColoredSurface;
+
+  /// Getter to know if we are on a border state
+  bool get onBorderRadiusState => _onBorderRadiusState;
 
   ThemeController() {
     /// Initialize the theme based on the system's current brightness setting
@@ -84,6 +89,14 @@ class ThemeController extends ChangeNotifier with WidgetsBindingObserver {
     bool newValue = value ?? false;
     if (_onColoredSurface != newValue) {
       _onColoredSurface = newValue;
+      notifyListeners();
+    }
+  }
+
+  void setOnBorderRadiusState(bool? value) {
+    bool newValue = value ?? false;
+    if (_onBorderRadiusState != newValue) {
+      _onBorderRadiusState = newValue;
       notifyListeners();
     }
   }

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Library] wrong role for checkbox a11y ([#261](https://github.com/Orange-OpenSource/ouds-flutter/issues/261))
 
+### Changed
+- [Library] Refactor with custom configuration Rounded `Button`, `Tag` and `TextInput` ([#299](-https://github.com/Orange-OpenSource/ouds-flutter/issues/299))
+
+
 ## [0.4.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.3.0...0.4.0) - 2025-07-11
 
 ### Added

--- a/ouds_core/README.md
+++ b/ouds_core/README.md
@@ -32,12 +32,13 @@ It is intended to replace internal frameworks and the previous [ODS](https://git
 
 ## Tokens version
 
-- **Version**: 1.2.0.
+- **Version**: 1.5.0.
 
 ## Other OUDS Libraries
 
 - **ouds_theme_contract**: Contains the semantic tokens and component tokens.
 - **ouds_theme_orange**: Contains the theme for the Orange brand.
+- **ouds_theme_sosh**: Contains the theme for the Sosh brand.
 
 ## Build
 
@@ -62,14 +63,14 @@ It is intended to replace internal frameworks and the previous [ODS](https://git
 ### Pubspec.yaml
 
 ```Dart
-  # Global raw token
-  ouds_global_raw_tokens: ^0.5.0
   # Core
   ouds_core: ^0.5.0
   # Orange Theme contract
   ouds_theme_contract: ^0.5.0
   # Orange Theme
   ouds_theme_orange: ^0.5.0
+  # Sosh Theme
+  ouds_theme_sosh: ^0.5.0
 
 dependency_overrides:
   intl: ^0.20.2
@@ -80,6 +81,9 @@ dependency_overrides:
 ### Localization
 
 To set up localization for the `ouds_core` library, you need to set the `OudsLocalizations.delegate` in the `localizationsDelegates` properties of the `MaterialApp`. 
+
+
+### Implementation
 
 ```Dart
     return MaterialApp(
@@ -98,6 +102,38 @@ To set up localization for the `ouds_core` library, you need to set the `OudsLoc
       },
     );
 ```
+### Custom Implementation 
+
+To customize the Orange theme (e.g., apply rounded corners or adjust spacing), wrap the `OudsTheme` with `OudsThemeConfigModel`.
+
+This allows you to override style tokens for specific components such as border radius while preserving the overall structure and design principles of the Orange theme.
+
+```Dart
+    return MaterialApp(
+      title: 'Title',
+      theme: OrangeTheme().themeData,
+      darkTheme: OrangeTheme().darkThemeData,
+      debugShowCheckedModeBanner: false,
+      home: const HomePage(title: 'title'),
+      builder: (context, child) {
+        // Custom configuration with `OudsThemeConfigModel`.
+        return OudsThemeConfigModel(
+          button: OudsButtonConfig(rounded: OudsButtonConfigBorder.radiusRounded), // Apply rounded corners for the button.
+          tag: OudsTagConfig(rounded: OudsTagConfigBorder.radiusDefault), // Apply rounded corners for the tag.
+          textInput: OudsTextInputConfig(rounded: OudsTextInputConfigBorder.radiusDefault),// Apply rounded corners for the text input.
+          // Wrap with `OudsTheme` for theme customization.
+          child: OudsTheme(
+            themeContract: themeController.currentTheme,
+            themeMode: themeController.themeMode,
+            onColoredSurface: themeController.onColoredSurface,
+            child: child ?? Container(),
+          ),
+        );
+      },
+    );
+```
+
+
 
 ## Copyright and license
 

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -13,6 +13,8 @@
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
+import 'package:ouds_theme_contract/config/component/ouds_button_config.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// Used to apply a border with color, width and radius associated to the hierarchy
@@ -101,6 +103,19 @@ class OudsButtonBorderModifier {
       default:
         return BorderSide(
             color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultDisabled : theme.componentsTokens(context).button.colorBorderDefaultDisabled, width: theme.componentsTokens(context).button.borderWidthDefault);
+    }
+  }
+
+  /// Static method to get the border radius for a button based on the border parameter.
+  /// Returns a [BorderRadius] object with the appropriate radius value.
+  static BorderRadius getBorderRadius(BuildContext context) {
+    final button = OudsTheme.of(context).componentsTokens(context).button;
+    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? OudsButtonConfigBorder.radiusDefault;
+    switch (buttonRounded) {
+      case OudsButtonConfigBorder.radiusRounded:
+        return BorderRadius.circular(button.borderRadiusRounded);
+      case OudsButtonConfigBorder.radiusDefault:
+        return BorderRadius.circular(button.borderRadiusDefault);
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -110,11 +110,11 @@ class OudsButtonBorderModifier {
   /// Returns a [BorderRadius] object with the appropriate radius value.
   static BorderRadius getBorderRadius(BuildContext context) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
-    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? OudsButtonConfigBorder.radiusDefault;
+    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
     switch (buttonRounded) {
-      case OudsButtonConfigBorder.radiusRounded:
+      case true:
         return BorderRadius.circular(button.borderRadiusRounded);
-      case OudsButtonConfigBorder.radiusDefault:
+      case false:
         return BorderRadius.circular(button.borderRadiusDefault);
     }
   }

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -25,7 +25,6 @@ class OudsButtonStyleModifier {
     required OudsButtonLayout layout,
     OudsButtonStyle? style,
     required bool isPressed,
-    required bool isRounded,
   }) {
     double iconSize;
     if (layout == OudsButtonLayout.iconOnly) {
@@ -53,7 +52,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: isRounded ? BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusRounded) : BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
+          borderRadius: OudsButtonBorderModifier.getBorderRadius(context),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -25,6 +25,7 @@ class OudsButtonStyleModifier {
     required OudsButtonLayout layout,
     OudsButtonStyle? style,
     required bool isPressed,
+    required bool isRounded,
   }) {
     double iconSize;
     if (layout == OudsButtonLayout.iconOnly) {
@@ -52,7 +53,7 @@ class OudsButtonStyleModifier {
       side: OudsButtonBorderModifier.resolveBorderColor(context, hierarchy, style),
       shape: WidgetStateProperty.all<RoundedRectangleBorder>(
         RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
+          borderRadius: isRounded ? BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusRounded) : BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
         ),
       ),
       padding: WidgetStateProperty.all<EdgeInsetsGeometry>(

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -14,6 +14,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// The [OudsButtonHierarchy] enum defines the visual importance of the button within the UI.
@@ -152,13 +153,17 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconAndText(BuildContext context) {
+    final themeConfig = OudsThemeConfigModel.of(context);
+    final isButtonRounded = themeConfig?.button.rounded ?? true;
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
           child: OutlinedButton(
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
             child: Stack(
               alignment: Alignment.center,
               children: [
@@ -188,7 +193,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
               child: Stack(
                 alignment: Alignment.center,
                 children: [
@@ -225,6 +230,10 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconOnly(BuildContext context) {
+    final themeConfig = OudsThemeConfigModel.of(context);
+    final isButtonRounded = themeConfig?.button.rounded ?? true;
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return Semantics(
@@ -232,7 +241,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: ExcludeSemantics(
             child: IconButton(
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
               onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
               icon: widget.icon!,
             ),
@@ -244,7 +253,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: IconButton(
             onPressed: null,
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
             icon: Stack(
               alignment: Alignment.center,
               children: [
@@ -261,12 +270,17 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonTextOnly(BuildContext context) {
+    final themeConfig = OudsThemeConfigModel.of(context);
+    final isButtonRounded = themeConfig?.button.rounded ?? true;
+    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
+
+    print("isButtonRounded: $isButtonRounded");
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
           child: OutlinedButton(
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             child: Text(
               widget.label ?? "",
@@ -281,7 +295,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed, isRounded: isButtonRounded),
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -14,7 +14,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
-import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// The [OudsButtonHierarchy] enum defines the visual importance of the button within the UI.
@@ -153,17 +152,13 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconAndText(BuildContext context) {
-    final themeConfig = OudsThemeConfigModel.of(context);
-    final isButtonRounded = themeConfig?.button.rounded ?? true;
-    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
-
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
           child: OutlinedButton(
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
             child: Stack(
               alignment: Alignment.center,
               children: [
@@ -193,7 +188,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
               child: Stack(
                 alignment: Alignment.center,
                 children: [
@@ -230,10 +225,6 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonIconOnly(BuildContext context) {
-    final themeConfig = OudsThemeConfigModel.of(context);
-    final isButtonRounded = themeConfig?.button.rounded ?? true;
-    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
-
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return Semantics(
@@ -241,7 +232,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: ExcludeSemantics(
             child: IconButton(
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
               onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
               icon: widget.icon!,
             ),
@@ -253,7 +244,7 @@ class _OudsButtonState extends State<OudsButton> {
           button: true,
           child: IconButton(
             onPressed: null,
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
             icon: Stack(
               alignment: Alignment.center,
               children: [
@@ -270,17 +261,12 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonTextOnly(BuildContext context) {
-    final themeConfig = OudsThemeConfigModel.of(context);
-    final isButtonRounded = themeConfig?.button.rounded ?? true;
-    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
-
-    print("isButtonRounded: $isButtonRounded");
     switch (widget.style) {
       case OudsButtonStyle.defaultStyle:
         return ClipRRect(
           borderRadius: BorderRadius.circular(OudsTheme.of(context).componentsTokens(context).button.borderRadiusDefault),
           child: OutlinedButton(
-            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed, isRounded: isButtonRounded),
+            style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, isPressed: _isPressed),
             onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
             child: Text(
               widget.label ?? "",
@@ -295,7 +281,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: ExcludeSemantics(
             child: OutlinedButton(
               onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed, isRounded: isButtonRounded),
+              style: OudsButtonStyleModifier.buildButtonStyle(context, hierarchy: widget.hierarchy, layout: widget.layout, style: widget.style, isPressed: _isPressed),
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/ouds_theme_contract/CHANGELOG.md
+++ b/ouds_theme_contract/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Tokens: `badge` ([#238](https://github.com/Orange-OpenSource/ouds-flutter/issues/#238))
 
 ### Changed
+- [Library] Refactor with custom configuration Rounded `Button`, `Tag` and `TextInput` ([#299](-https://github.com/Orange-OpenSource/ouds-flutter/issues/299))
 - [Library] Update tokens 1.2.0 ([#236](https://github.com/Orange-OpenSource/ouds-flutter/issues/236))
 - [Library] Update tokens 1.1.0 ([#225](https://github.com/Orange-OpenSource/ouds-flutter/issues/225))
 - [Library] Token `size` values now adapt based on device type ([#218](https://github.com/Orange-OpenSource/ouds-flutter/issues/218))

--- a/ouds_theme_contract/lib/config/component/ouds_button_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_button_config.dart
@@ -11,10 +11,15 @@
  * //
  */
 
+enum OudsButtonConfigBorder {
+  radiusDefault,
+  radiusRounded;
+}
+
 class OudsButtonConfig {
-  final bool? rounded;
+  final OudsButtonConfigBorder rounded;
 
   const OudsButtonConfig({
-    this.rounded = true,
+    this.rounded = OudsButtonConfigBorder.radiusDefault,
   });
 }

--- a/ouds_theme_contract/lib/config/component/ouds_button_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_button_config.dart
@@ -1,0 +1,20 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+class OudsButtonConfig {
+  final bool? rounded;
+
+  const OudsButtonConfig({
+    this.rounded = true,
+  });
+}

--- a/ouds_theme_contract/lib/config/component/ouds_button_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_button_config.dart
@@ -11,15 +11,10 @@
  * //
  */
 
-enum OudsButtonConfigBorder {
-  radiusDefault,
-  radiusRounded;
-}
-
 class OudsButtonConfig {
-  final OudsButtonConfigBorder rounded;
+  final bool? rounded;
 
   const OudsButtonConfig({
-    this.rounded = OudsButtonConfigBorder.radiusDefault,
+    this.rounded = true,
   });
 }

--- a/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
@@ -10,10 +10,15 @@
  * // Software description: Flutter library of reusable graphical components
  * //
  */
+enum OudsTagConfigBorder {
+  radiusDefault,
+  radiusRounded;
+}
+
 class OudsTagConfig {
-  final bool? rounded;
+  final OudsTagConfigBorder rounded;
 
   const OudsTagConfig({
-    this.rounded = true,
+    this.rounded = OudsTagConfigBorder.radiusDefault,
   });
 }

--- a/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
@@ -1,0 +1,19 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+class OudsTagConfig {
+  final bool? rounded;
+
+  const OudsTagConfig({
+    this.rounded = true,
+  });
+}

--- a/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_tag_config.dart
@@ -10,15 +10,11 @@
  * // Software description: Flutter library of reusable graphical components
  * //
  */
-enum OudsTagConfigBorder {
-  radiusDefault,
-  radiusRounded;
-}
 
 class OudsTagConfig {
-  final OudsTagConfigBorder rounded;
+  final bool? rounded;
 
   const OudsTagConfig({
-    this.rounded = OudsTagConfigBorder.radiusDefault,
+    this.rounded = true,
   });
 }

--- a/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
@@ -10,11 +10,15 @@
  * // Software description: Flutter library of reusable graphical components
  * //
  */
+enum OudsTextInputConfigBorder {
+  radiusDefault,
+  radiusRounded;
+}
 
 class OudsTextInputConfig {
-  final bool? rounded;
+  final OudsTextInputConfigBorder rounded;
 
   const OudsTextInputConfig({
-    this.rounded = true,
+    this.rounded = OudsTextInputConfigBorder.radiusDefault,
   });
 }

--- a/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
@@ -1,0 +1,20 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+class OudsTextInputConfig {
+  final bool? rounded;
+
+  const OudsTextInputConfig({
+    this.rounded = true,
+  });
+}

--- a/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
+++ b/ouds_theme_contract/lib/config/component/ouds_text_input_config.dart
@@ -16,9 +16,9 @@ enum OudsTextInputConfigBorder {
 }
 
 class OudsTextInputConfig {
-  final OudsTextInputConfigBorder rounded;
+  final bool? rounded;
 
   const OudsTextInputConfig({
-    this.rounded = OudsTextInputConfigBorder.radiusDefault,
+    this.rounded = true,
   });
 }

--- a/ouds_theme_contract/lib/config/ouds_theme_config_model.dart
+++ b/ouds_theme_contract/lib/config/ouds_theme_config_model.dart
@@ -16,14 +16,14 @@ import 'package:ouds_theme_contract/config/component/ouds_tag_config.dart';
 import 'package:ouds_theme_contract/config/component/ouds_text_input_config.dart';
 
 class OudsThemeConfigModel extends InheritedWidget {
-  final OudsButtonConfig button;
-  final OudsTagConfig tag;
-  final OudsTextInputConfig textInput;
+  final OudsButtonConfig? button;
+  final OudsTagConfig? tag;
+  final OudsTextInputConfig? textInput;
 
   const OudsThemeConfigModel({
-    required this.button,
-    required this.tag,
-    required this.textInput,
+    this.button,
+    this.tag,
+    this.textInput,
     required Widget child,
     Key? key,
   }) : super(key: key, child: child);

--- a/ouds_theme_contract/lib/config/ouds_theme_config_model.dart
+++ b/ouds_theme_contract/lib/config/ouds_theme_config_model.dart
@@ -1,0 +1,39 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+import 'package:flutter/material.dart';
+import 'package:ouds_theme_contract/config/component/ouds_button_config.dart';
+import 'package:ouds_theme_contract/config/component/ouds_tag_config.dart';
+import 'package:ouds_theme_contract/config/component/ouds_text_input_config.dart';
+
+class OudsThemeConfigModel extends InheritedWidget {
+  final OudsButtonConfig button;
+  final OudsTagConfig tag;
+  final OudsTextInputConfig textInput;
+
+  const OudsThemeConfigModel({
+    required this.button,
+    required this.tag,
+    required this.textInput,
+    required Widget child,
+    Key? key,
+  }) : super(key: key, child: child);
+
+  static OudsThemeConfigModel? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<OudsThemeConfigModel>();
+  }
+
+  @override
+  bool updateShouldNotify(covariant OudsThemeConfigModel oldWidget) {
+    return button != oldWidget.button || tag != oldWidget.tag || textInput != oldWidget.textInput;
+  }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [x] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
