### PR TITLE
fix: skip image semantics and expose loading state to accessibility (366)

### DIFF
--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- [Library] Tag with bullet/icon has incorrect name a11y ([#366](https://github.com/Orange-OpenSource/ouds-flutter/issues/366))
 - [Library] move dartdoc to dev_dependencies ([#350](https://github.com/Orange-OpenSource/ouds-flutter/issues/350))
 - [Library] inaccessible suggestion `chip` ([#331](https://github.com/Orange-OpenSource/ouds-flutter/issues/331))
 

--- a/ouds_core/lib/components/tag/ouds_tag.dart
+++ b/ouds_core/lib/components/tag/ouds_tag.dart
@@ -112,6 +112,7 @@ class OudsTag extends StatefulWidget {
     final statusModifier = OudsTagStatusModifier(context);
 
     return SvgPicture.asset(
+      excludeFromSemantics: true,
       assetName ?? statusModifier.getStatusIcon(controlItemState)!,
       package: assetName == null ? OudsTheme.of(context).packageName : null,
       width: width,
@@ -190,10 +191,13 @@ class _OudsTagState extends State<OudsTag> {
                   SizedBox(
                     width: widthAndHeightAssetsContainer[OudsTagDimensions.width.name],
                     height: widthAndHeightAssetsContainer[OudsTagDimensions.height.name],
-                    child: CircularProgressIndicator(
-                      padding: tagSizeModifier.getAssetsPadding(widget.size, OudsTagLayout.textAndLoader),
-                      color: tagStatusModifier.getStatusTextAndLoaderColor(widget.status, widget.hierarchy),
-                      strokeWidth: OudsTheme.of(context).spaceScheme(context).scaledThreeExtraSmall,
+                    child: Semantics(
+                      label: l10n?.core_tag_loading_a11y,
+                      child: CircularProgressIndicator(
+                        padding: tagSizeModifier.getAssetsPadding(widget.size, OudsTagLayout.textAndLoader),
+                        color: tagStatusModifier.getStatusTextAndLoaderColor(widget.status, widget.hierarchy),
+                        strokeWidth: OudsTheme.of(context).spaceScheme(context).scaledThreeExtraSmall,
+                      ),
                     ),
                   ),
                   SizedBox(width: tagSizeModifier.getSizeColumnGap(widget.size)),
@@ -279,6 +283,7 @@ class _OudsTagState extends State<OudsTag> {
                     width: widthAndHeightAssetsContainer[OudsTagDimensions.width.name],
                     height: widthAndHeightAssetsContainer[OudsTagDimensions.height.name],
                     child: SvgPicture.asset(
+                      excludeFromSemantics: true,
                       AppAssets.icons.roundedBullet,
                       package: OudsTheme.of(context).packageName,
                       fit: BoxFit.contain,

--- a/ouds_core/lib/l10n/gen/ouds_localizations.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations.dart
@@ -200,6 +200,12 @@ abstract class OudsLocalizations {
   /// **'Double tap to delete this item'**
   String get core_components_tag_tag_input_hint_a11y;
 
+  /// No description provided for @core_tag_loading_a11y.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading'**
+  String get core_tag_loading_a11y;
+
   /// No description provided for @core_components_text_input_input_a11y.
   ///
   /// In en, this message translates to:

--- a/ouds_core/lib/l10n/gen/ouds_localizations_ar.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations_ar.dart
@@ -63,5 +63,8 @@ class OudsLocalizationsAr extends OudsLocalizations {
       'انقر مرتين لحذف هذا العنصر';
 
   @override
+  String get core_tag_loading_a11y => 'Loading';
+
+  @override
   String get core_components_text_input_input_a11y => 'حقل النص';
 }

--- a/ouds_core/lib/l10n/gen/ouds_localizations_en.dart
+++ b/ouds_core/lib/l10n/gen/ouds_localizations_en.dart
@@ -63,5 +63,8 @@ class OudsLocalizationsEn extends OudsLocalizations {
       'Double tap to delete this item';
 
   @override
+  String get core_tag_loading_a11y => 'Loading';
+
+  @override
   String get core_components_text_input_input_a11y => 'TextField';
 }

--- a/ouds_core/lib/l10n/ouds_flutter_ar.arb
+++ b/ouds_core/lib/l10n/ouds_flutter_ar.arb
@@ -25,5 +25,6 @@
     "core_components_tag_tag_input_a11y":  "إدخال الوسم",
     "core_components_tag_a11y": "وسم",
     "core_components_tag_tag_input_hint_a11y": "انقر مرتين لحذف هذا العنصر",
+    "core_tag_loading_a11y": "جاري التحميل",
     "core_components_text_input_input_a11y":  "حقل النص"
 }

--- a/ouds_core/lib/l10n/ouds_flutter_en.arb
+++ b/ouds_core/lib/l10n/ouds_flutter_en.arb
@@ -25,6 +25,7 @@
     "core_components_tag_tag_input_a11y":  "Tag Input",
     "core_components_tag_a11y": "Tag",
     "core_components_tag_tag_input_hint_a11y": "Double tap to delete this item",
+    "core_tag_loading_a11y": "Loading",
 
     "@_OUDS_TEXT_INPUT": {},
     "core_components_text_input_input_a11y":  "TextField"


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#366
### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [x] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
