### PR TITLE
bug: a11y badge text enlargement is not applied to icon 368

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Tool] Change the favicon to orange favicon in the documentation ([#371](https://github.com/Orange-OpenSource/ouds-flutter/issues/371))
 
 ### Fixed
+- [DemoApp][Library] `Badge`: Text enlargement is not applied to icon ([#368](https://github.com/Orange-OpenSource/ouds-flutter/issues/368))
 - [Library] Android High Contrast for Checkbox and Radio button ([#327](https://github.com/Orange-OpenSource/ouds-flutter/issues/327))
 - [Library] Preserve @nodoc header in generated l10n files ([#412](https://github.com/Orange-OpenSource/ouds-flutter/issues/412))
 - [Library] Error status not read by Talkback and Voice Over `Switch` ([#365](https://github.com/Orange-OpenSource/ouds-flutter/issues/365))

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Tool] Change the favicon to orange favicon in the documentation ([#371](https://github.com/Orange-OpenSource/ouds-flutter/issues/371))
 
 ### Fixed
-- [DemoApp][Library] `Badge`: Text enlargement is not applied to icon ([#368](https://github.com/Orange-OpenSource/ouds-flutter/issues/368))
+- [Library] `Badge`: Text enlargement is not applied to icon ([#368](https://github.com/Orange-OpenSource/ouds-flutter/issues/368))
 - [Library] Android High Contrast for Checkbox and Radio button ([#327](https://github.com/Orange-OpenSource/ouds-flutter/issues/327))
 - [Library] Preserve @nodoc header in generated l10n files ([#412](https://github.com/Orange-OpenSource/ouds-flutter/issues/412))
 - [Library] Error status not read by Talkback and Voice Over `Switch` ([#365](https://github.com/Orange-OpenSource/ouds-flutter/issues/365))

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Tool] Change the favicon to orange favicon in the documentation ([#371](https://github.com/Orange-OpenSource/ouds-flutter/issues/371))
 
 ### Fixed
+- [Library] `Badge`: Text enlargement is not applied to icon ([#368](https://github.com/Orange-OpenSource/ouds-flutter/issues/368))
 - [Library] Android High Contrast for Checkbox and Radio button ([#327](https://github.com/Orange-OpenSource/ouds-flutter/issues/327))
 - [Library] Preserve @nodoc header in generated l10n files ([#412](https://github.com/Orange-OpenSource/ouds-flutter/issues/412))
 - [Library] Error status not read by Talkback and Voice Over `Switch` ([#365](https://github.com/Orange-OpenSource/ouds-flutter/issues/365))

--- a/ouds_core/lib/components/badge/internal/ouds_badge_size_modifier.dart
+++ b/ouds_core/lib/components/badge/internal/ouds_badge_size_modifier.dart
@@ -30,7 +30,7 @@ class OudsBadgeSizeModifier {
   OudsBadgeSizeModifier(this.context);
 
   /// Retrieves the size (double) for the badge based on the provided size enum.
-  double? getSize(OudsBadgeSize? state) {
+  double getSize(OudsBadgeSize? state) {
     final theme = OudsTheme.of(context).componentsTokens(context).badge;
 
     switch (state) {
@@ -44,6 +44,23 @@ class OudsBadgeSizeModifier {
         return theme.sizeLarge;
       case null:
         return theme.sizeMedium;
+    }
+  }
+
+  /// Retrieves the size of icon (double) for the badge based on the provided size enum.
+  double? getIconSize(OudsBadgeSize? state) {
+    final theme = OudsTheme.of(context).componentsTokens(context).badge;
+
+    switch (state) {
+      case OudsBadgeSize.xsmall:
+      case OudsBadgeSize.small:
+        return null;
+      case OudsBadgeSize.medium:
+        return theme.sizeXsmall + 2;
+      case OudsBadgeSize.large:
+        return theme.sizeSmall + 2;
+      case null:
+        return null;
     }
   }
 }

--- a/ouds_core/lib/components/badge/internal/ouds_badge_size_modifier.dart
+++ b/ouds_core/lib/components/badge/internal/ouds_badge_size_modifier.dart
@@ -46,21 +46,4 @@ class OudsBadgeSizeModifier {
         return theme.sizeMedium;
     }
   }
-
-  /// Retrieves the size of icon (double) for the badge based on the provided size enum.
-  double? getIconSize(OudsBadgeSize? state) {
-    final theme = OudsTheme.of(context).componentsTokens(context).badge;
-
-    switch (state) {
-      case OudsBadgeSize.xsmall:
-      case OudsBadgeSize.small:
-        return null;
-      case OudsBadgeSize.medium:
-        return theme.sizeXsmall + 2;
-      case OudsBadgeSize.large:
-        return theme.sizeSmall + 2;
-      case null:
-        return null;
-    }
-  }
 }

--- a/ouds_core/lib/components/badge/ouds_badge.dart
+++ b/ouds_core/lib/components/badge/ouds_badge.dart
@@ -118,6 +118,7 @@ class _OudsBadgeState extends State<OudsBadge> {
                 : EdgeInsets.only(left: badge.spacePaddingInlineMedium, right: badge.spacePaddingInlineMedium),
         backgroundColor: badgeStatusModifier.getStatusColor(widget.status),
         label: badgeLabel,
+        child: widget.child,
       ),
     );
   }

--- a/ouds_core/lib/components/badge/ouds_badge.dart
+++ b/ouds_core/lib/components/badge/ouds_badge.dart
@@ -141,25 +141,22 @@ class _OudsBadgeState extends State<OudsBadge> {
   /// Static method to build icon from asset name
   Widget _buildBadgeWithIcon(BuildContext context, String? assetName) {
     final badgeStatusModifier = OudsBadgeStatusModifier(context);
-    final badgeSizeModifier = OudsBadgeSizeModifier(context);
-    final textScaler = MediaQuery.of(context).textScaler;
 
     if (assetName == null) {
       return SizedBox.shrink(); // widget empty
     }
     // this condition is two eliminate the text when we are in XSmall or Small
     return widget.size == OudsBadgeSize.large || widget.size == OudsBadgeSize.medium
-        ? SvgPicture.asset(
+        ? SizedBox.expand(
+          child: SvgPicture.asset(
             assetName,
-            width: textScaler.scale(badgeSizeModifier.getIconSize(widget.size)!),
-            height: textScaler.scale(badgeSizeModifier.getIconSize(widget.size)!),
             fit: BoxFit.contain,
             colorFilter: ColorFilter.mode(
               badgeStatusModifier.getStatusTextAndIconColor((widget.status)),
               BlendMode.srcIn,
             ),
-          )
-        : Container();
+          ),
+    ) : Container();
   }
 
   /// Formats a numeric label, replacing values >= 100 with "+99"

--- a/ouds_core/lib/components/badge/ouds_badge.dart
+++ b/ouds_core/lib/components/badge/ouds_badge.dart
@@ -98,15 +98,17 @@ class _OudsBadgeState extends State<OudsBadge> {
         badgeLabel = _buildBadgeWithNumber(context);
         break;
     }
+    final textScaler = MediaQuery.of(context).textScaler;
+    final scaledSize = textScaler.scale(badgeSizeModifier.getSize(widget.size));
 
     return Container(
-      width: type == Type.count ? null : badgeSizeModifier.getSize(widget.size),
-      height: type == Type.count ? null : badgeSizeModifier.getSize(widget.size),
+      width: type == Type.count ? null : scaledSize,
+      height: type == Type.count ? null : scaledSize,
       constraints: BoxConstraints(
-        minHeight: badgeSizeModifier.getSize(widget.size)!,
-        minWidth: badgeSizeModifier.getSize(widget.size)!,
-        maxHeight: type == Type.count ? double.infinity : badgeSizeModifier.getSize(widget.size)!,
-        maxWidth: type == Type.count ? double.infinity : badgeSizeModifier.getSize(widget.size)!,
+        minHeight: scaledSize,
+        minWidth: scaledSize,
+        maxHeight: type == Type.count ? double.infinity : scaledSize,
+        maxWidth: type == Type.count ? double.infinity : scaledSize,
       ),
       child: Badge(
         padding: widget.icon != null
@@ -116,7 +118,6 @@ class _OudsBadgeState extends State<OudsBadge> {
                 : EdgeInsets.only(left: badge.spacePaddingInlineMedium, right: badge.spacePaddingInlineMedium),
         backgroundColor: badgeStatusModifier.getStatusColor(widget.status),
         label: badgeLabel,
-        child: widget.child,
       ),
     );
   }
@@ -140,6 +141,8 @@ class _OudsBadgeState extends State<OudsBadge> {
   /// Static method to build icon from asset name
   Widget _buildBadgeWithIcon(BuildContext context, String? assetName) {
     final badgeStatusModifier = OudsBadgeStatusModifier(context);
+    final badgeSizeModifier = OudsBadgeSizeModifier(context);
+    final textScaler = MediaQuery.of(context).textScaler;
 
     if (assetName == null) {
       return SizedBox.shrink(); // widget empty
@@ -148,6 +151,8 @@ class _OudsBadgeState extends State<OudsBadge> {
     return widget.size == OudsBadgeSize.large || widget.size == OudsBadgeSize.medium
         ? SvgPicture.asset(
             assetName,
+            width: textScaler.scale(badgeSizeModifier.getIconSize(widget.size)!),
+            height: textScaler.scale(badgeSizeModifier.getIconSize(widget.size)!),
             fit: BoxFit.contain,
             colorFilter: ColorFilter.mode(
               badgeStatusModifier.getStatusTextAndIconColor((widget.status)),


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#368

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test (dark mode, RTL, landscape display, tablet)
- [ ] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [ ] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [ ] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
