### PR TITLE
fix: child Element Not Rendered Properly in Badge

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.0.0...develop)
 
+### Added
+
+### Changed
+
+### Fixed
+- [DemoApp][Library] `Badge` Child Element Not Rendered Properly ([#557](https://github.com/Orange-OpenSource/ouds-flutter/issues/557))
+
 ## [1.0.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.7.0...1.0.0) - 2025-12-19
 ### Added
 - [DemoApp][Library] Create component - `Phone Number Input` ([#326](https://github.com/Orange-OpenSource/ouds-flutter/issues/326))

--- a/app/lib/ui/components/badge/badge_demo_screen.dart
+++ b/app/lib/ui/components/badge/badge_demo_screen.dart
@@ -27,6 +27,7 @@ import 'package:ouds_flutter_demo/ui/utilities/code.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_chips.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_dropdown_menu.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section.dart';
+import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/dismiss_keyboard.dart';
@@ -36,7 +37,6 @@ import 'package:ouds_flutter_demo/ui/utilities/theme_colored_box.dart';
 import 'package:ouds_theme_contract/ouds_component_version.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:provider/provider.dart';
-import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 
 /// This screen displays a radio_button demo and allows customization of radio_button properties
 class BadgeDemoScreen extends StatefulWidget {
@@ -142,7 +142,7 @@ class _BadgeDemoState extends State<_BadgeDemo> {
             children: [
               OudsBadge(
                 label: BadgeCustomizationUtils.getType(customizationState!.selectedType) == BadgeEnumType.count ? BadgeCustomizationUtils.getNumberText(customizationState!) : null,
-                icon: BadgeCustomizationUtils.getIcon(customizationState,themeController),
+                icon: BadgeCustomizationUtils.getIcon(customizationState, themeController),
                 size: BadgeCustomizationUtils.getSize(customizationState!.selectedState),
                 status: BadgeCustomizationUtils.getStatus(customizationState!.selectedStatus),
                 enabled: customizationState!.hasEnabled,
@@ -159,11 +159,11 @@ class _BadgeDemoState extends State<_BadgeDemo> {
             children: [
               OudsBadge(
                 label: BadgeCustomizationUtils.getType(customizationState!.selectedType) == BadgeEnumType.count ? BadgeCustomizationUtils.getNumberText(customizationState!) : null,
-                icon: BadgeCustomizationUtils.getIcon(customizationState,themeController),
+                icon: BadgeCustomizationUtils.getIcon(customizationState, themeController),
                 size: BadgeCustomizationUtils.getSize(customizationState!.selectedState),
                 status: BadgeCustomizationUtils.getStatus(customizationState!.selectedStatus),
                 enabled: customizationState!.hasEnabled,
-                semanticsLabel: BadgeCustomizationUtils().getSemanticLabel(context,customizationState!),
+                semanticsLabel: BadgeCustomizationUtils().getSemanticLabel(context, customizationState!),
               )
             ],
           ),
@@ -218,7 +218,6 @@ class _CustomizationContentState extends State<_CustomizationContent> {
             });
           },
         ),
-
         CustomizableChips<BadgeEnumType>(
           title: BadgeEnumType.enumName(context),
           options: style,
@@ -264,7 +263,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                   width: theme.paddingBlockMedium,
                   height: theme.paddingBlockMedium,
                   decoration: BoxDecoration(
-                    color: badgeStatusModifier.getStatusColor(BadgeCustomizationUtils.getStatus(status),true),
+                    color: badgeStatusModifier.getStatusColor(BadgeCustomizationUtils.getStatus(status), true),
                     shape: BoxShape.rectangle,
                   ),
                 );

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.0.0...develop)
 
+### Added
+
+### Changed
+
+### Fixed
+[Library] `Badge` Child Element Not Rendered Properly ([#557](https://github.com/Orange-OpenSource/ouds-flutter/issues/557))
+
 ## [1.0.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.7.0...1.0.0) - 2025-12-19
 ### Added
 - [Library] Create component - `Phone Number Input` ([#326](https://github.com/Orange-OpenSource/ouds-flutter/issues/326))

--- a/ouds_core/lib/components/badge/ouds_badge.dart
+++ b/ouds_core/lib/components/badge/ouds_badge.dart
@@ -92,16 +92,7 @@ class OudsBadge extends StatefulWidget {
   final bool enabled;
   final String? semanticsLabel;
 
-  const OudsBadge({
-    super.key,
-    required this.status,
-    this.size = OudsBadgeSize.medium,
-    this.label,
-    this.icon,
-    this.child,
-    this.enabled = true,
-    this.semanticsLabel
-  });
+  const OudsBadge({super.key, required this.status, this.size = OudsBadgeSize.medium, this.label, this.icon, this.child, this.enabled = true, this.semanticsLabel});
 
   @override
   State<OudsBadge> createState() => _OudsBadgeState();
@@ -130,27 +121,32 @@ class _OudsBadgeState extends State<OudsBadge> {
     final scaledSize = textScaler.scale(badgeSizeModifier.getSize(widget.size));
 
     return Container(
-      width: type == Type.count ? null : scaledSize,
-      height: type == Type.count ? null : scaledSize,
+      width: type == Type.count || type == Type.standard ? null : scaledSize,
+      height: type == Type.count || type == Type.standard ? null : scaledSize,
       constraints: BoxConstraints(
         minHeight: scaledSize,
         minWidth: scaledSize,
-        maxHeight: type == Type.count ? double.infinity : scaledSize,
-        maxWidth: type == Type.count ? double.infinity : scaledSize,
+        maxHeight: type == Type.count || type == Type.standard ? double.infinity : scaledSize,
+        maxWidth: type == Type.count || type == Type.standard ? double.infinity : scaledSize,
       ),
       child: Semantics(
         label: widget.semanticsLabel,
         enabled: widget.enabled,
-        child: Badge(
-          padding: widget.icon != null
-              ? EdgeInsets.only(left: badge.spaceInset, right: badge.spaceInset)
-              : widget.size == OudsBadgeSize.large
-                  ? EdgeInsets.only(left: badge.spacePaddingInlineLarge, right: badge.spacePaddingInlineLarge)
-                  : EdgeInsets.only(left: badge.spacePaddingInlineMedium, right: badge.spacePaddingInlineMedium),
-          backgroundColor: badgeStatusModifier.getStatusColor(widget.status,widget.enabled),
-          label: badgeLabel,
-          child: widget.child,
-        ),
+        child: Type.standard == type
+            ? Badge(
+                backgroundColor: badgeStatusModifier.getStatusColor(widget.status, widget.enabled),
+                child: widget.child,
+              )
+            : Badge(
+                padding: widget.icon != null
+                    ? EdgeInsets.only(left: badge.spaceInset, right: badge.spaceInset)
+                    : widget.size == OudsBadgeSize.large
+                        ? EdgeInsets.only(left: badge.spacePaddingInlineLarge, right: badge.spacePaddingInlineLarge)
+                        : EdgeInsets.only(left: badge.spacePaddingInlineMedium, right: badge.spacePaddingInlineMedium),
+                backgroundColor: badgeStatusModifier.getStatusColor(widget.status, widget.enabled),
+                label: badgeLabel,
+                child: widget.child,
+              ),
       ),
     );
   }
@@ -162,14 +158,14 @@ class _OudsBadgeState extends State<OudsBadge> {
     // this condition is two eliminate the text when we are in XSmall or Small
     return widget.size == OudsBadgeSize.large || widget.size == OudsBadgeSize.medium
         ? ExcludeSemantics(
-          child: Text(
+            child: Text(
               _formattedLabel(),
               style: widget.size == OudsBadgeSize.large
-                  ? theme.typographyTokens.typeLabelDefaultMedium(context).copyWith(color: badgeStatusModifier.getStatusTextAndIconColor((widget.status),widget.enabled))
-                  : theme.typographyTokens.typeLabelDefaultSmall(context).copyWith(color: badgeStatusModifier.getStatusTextAndIconColor((widget.status),widget.enabled)),
+                  ? theme.typographyTokens.typeLabelDefaultMedium(context).copyWith(color: badgeStatusModifier.getStatusTextAndIconColor((widget.status), widget.enabled))
+                  : theme.typographyTokens.typeLabelDefaultSmall(context).copyWith(color: badgeStatusModifier.getStatusTextAndIconColor((widget.status), widget.enabled)),
               textAlign: TextAlign.center,
             ),
-        )
+          )
         : Container();
   }
 
@@ -181,21 +177,22 @@ class _OudsBadgeState extends State<OudsBadge> {
       return SizedBox.shrink(); // widget empty
     }
 
-   final icon = badgeStatusModifier.getStatusIcon(widget.status);
+    final icon = badgeStatusModifier.getStatusIcon(widget.status);
     // this condition is two eliminate the text when we are in XSmall or Small
     return widget.size == OudsBadgeSize.large || widget.size == OudsBadgeSize.medium
         ? SizedBox.expand(
-          child: SvgPicture.asset(
-            excludeFromSemantics: true,
-            icon ?? assetName,
-            fit: BoxFit.contain,
-            package: icon != null ? OudsTheme.of(context).packageName : null,
-            colorFilter: ColorFilter.mode(
-              badgeStatusModifier.getStatusTextAndIconColor((widget.status),widget.enabled),
-              BlendMode.srcIn,
+            child: SvgPicture.asset(
+              excludeFromSemantics: true,
+              icon ?? assetName,
+              fit: BoxFit.contain,
+              package: icon != null ? OudsTheme.of(context).packageName : null,
+              colorFilter: ColorFilter.mode(
+                badgeStatusModifier.getStatusTextAndIconColor((widget.status), widget.enabled),
+                BlendMode.srcIn,
+              ),
             ),
-          ),
-    ) : Container();
+          )
+        : Container();
   }
 
   /// Formats a numeric label, replacing values >= 100 with "+99"

--- a/ouds_core/lib/components/badge/ouds_badge.dart
+++ b/ouds_core/lib/components/badge/ouds_badge.dart
@@ -134,6 +134,13 @@ class _OudsBadgeState extends State<OudsBadge> {
         enabled: widget.enabled,
         child: Type.standard == type
             ? Badge(
+                smallSize: scaledSize,
+                alignment: widget.size == OudsBadgeSize.large
+                    ? AlignmentDirectional(5, -1.5)
+                    : widget.size == OudsBadgeSize.medium
+                        ? AlignmentDirectional(2, -1.3)
+                        : null,
+                padding: widget.size == OudsBadgeSize.large ? EdgeInsets.only(left: badge.spaceInset, right: badge.spaceInset) : null,
                 backgroundColor: badgeStatusModifier.getStatusColor(widget.status, widget.enabled),
                 child: widget.child,
               )


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

- [x] #557 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [x] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
