### PR TITLE
feat: let `Button` takes the screen full width

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Tool] Update `Flutter` to 3.38.0 and `Dart` Version to 3.10.8  ([#572](https://github.com/Orange-OpenSource/ouds-flutter/issues/572))
 
 ### Fixed
+- [Library] Keyboard focus is not visible on `button` component ([#473](https://github.com/Orange-OpenSource/ouds-flutter/issues/473))
 - [DemoApp] Activated tab `Navigation bar` is not highlighted ([#384](https://github.com/Orange-OpenSource/ouds-flutter/issues/384))
 - [DemoApp][Library] `Button`, `Chip`, `Link`, `Tag` components have text overflow ([#552](https://github.com/Orange-OpenSource/ouds-flutter/issues/552))
 - [Tool] Unsupported operation Web for ouds libs and demo app ([#559](https://github.com/Orange-OpenSource/ouds-flutter/issues/559))
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] `Text Input` Placeholder is read even if input is filled ([#471](https://github.com/Orange-OpenSource/ouds-flutter/issues/471))
 - [Library] `Text Input` Incorrect reading order ([#449](https://github.com/Orange-OpenSource/ouds-flutter/issues/449))
 - [DemoApp][Library] `Badge` Child Element Not Rendered Properly ([#557](https://github.com/Orange-OpenSource/ouds-flutter/issues/557))
+
 
 ## [1.0.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/0.7.0...1.0.0) - 2025-12-19
 ### Added

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [DemoApp][Library] Create component - `Bottom Navigation` ([#90](https://github.com/Orange-OpenSource/ouds-flutter/issues/90))
 
 ### Changed
+- [DemoApp][Library] Let `Button` takes the screen full width ([#577](https://github.com/Orange-OpenSource/ouds-flutter/issues/577))
 - [DemoApp] Use the tag to show the Component Design Version ([#501](https://github.com/Orange-OpenSource/ouds-flutter/issues/501))
 - [Tool] Update `Flutter` to 3.38.0 and `Dart` Version to 3.10.8  ([#572](https://github.com/Orange-OpenSource/ouds-flutter/issues/572))
 

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
@@ -533,6 +533,12 @@ abstract class AppLocalizations {
   /// **'Buttons allow users to make choices or perform an action. They have multiple styles for various needs.'**
   String get app_components_button_description_text;
 
+  /// No description provided for @app_components_button_fullWidth_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Full width'**
+  String get app_components_button_fullWidth_label;
+
   /// No description provided for @app_components_checkbox_label.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
@@ -237,6 +237,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'تسمح Buttons للمستخدمين باتخاذ قرارات أو تنفيذ إجراءات. وتتوفر بأنماط متعددة لتلبية احتياجات مختلفة.';
 
   @override
+  String get app_components_button_fullWidth_label => 'Full width';
+
+  @override
   String get app_components_checkbox_label => 'Checkbox';
 
   @override

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
@@ -237,6 +237,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Buttons allow users to make choices or perform an action. They have multiple styles for various needs.';
 
   @override
+  String get app_components_button_fullWidth_label => 'Full width';
+
+  @override
   String get app_components_checkbox_label => 'Checkbox';
 
   @override

--- a/app/lib/l10n/ouds_flutter_en.arb
+++ b/app/lib/l10n/ouds_flutter_en.arb
@@ -120,6 +120,7 @@
   "@_components_button": {},
   "app_components_button_label": "Button",
   "app_components_button_description_text": "Buttons allow users to make choices or perform an action. They have multiple styles for various needs.",
+  "app_components_button_fullWidth_label": "Full width",
 
   "@_components_checkbox": {},
   "app_components_checkbox_label": "Checkbox",

--- a/app/lib/ui/components/button/button_code_generator.dart
+++ b/app/lib/ui/components/button/button_code_generator.dart
@@ -40,15 +40,15 @@ class ButtonCodeGenerator {
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsButtonLayout.textOnly:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nlabel: "$label",\nappearance: ${appearance.toString()},${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconOnly:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconAndText:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
     }
 
@@ -69,6 +69,15 @@ class ButtonCodeGenerator {
     final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
     if (customizationState?.hasLoader == true) {
       return "\nloader: Loader(progress: null),";
+    } else {
+      return "";
+    }
+  }
+
+  static String fullWidthCodeModifier(BuildContext context) {
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    if (customizationState?.hasFullWidth == true) {
+      return "\nisFullWidth: ${customizationState?.hasFullWidth},";
     } else {
       return "";
     }

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -38,6 +38,7 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
   late final LayoutState layoutState;
   late final RoundedCornerState roundedCornerState;
   late final LoaderState loaderState;
+  late final FullWidthState fullWidthState;
 
   @override
   void initState() {
@@ -46,6 +47,7 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
     loaderState = LoaderState(setState, enabledState);
     layoutState = LayoutState(setState);
     roundedCornerState = RoundedCornerState(setState);
+    fullWidthState = FullWidthState(setState);
   }
 
   // Getter to determine if the 'OnColoredBox' should be disabled
@@ -70,6 +72,9 @@ class ButtonCustomizationState extends CustomizationWidgetState<ButtonCustomizat
 
   bool get hasLoader => loaderState.value;
   set hasLoader(bool value) => loaderState.value = value;
+
+  bool get hasFullWidth => fullWidthState.value;
+  set hasFullWidth(bool value) => fullWidthState.value = value;
 
   @override
   Widget build(BuildContext context) {
@@ -164,6 +169,21 @@ class RoundedCornerState {
   set value(bool newValue) {
     _setState(() {
       _hasRoundedCorner = newValue;
+    });
+  }
+}
+
+/// FullWidth State Management
+class FullWidthState {
+  FullWidthState(this._setState);
+
+  final void Function(void Function()) _setState;
+  bool _hasFullWidth = false;
+
+  bool get value => _hasFullWidth;
+  set value(bool newValue) {
+    _setState(() {
+      _hasFullWidth = newValue;
     });
   }
 }

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -142,6 +142,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
           appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
           loader: ButtonCustomizationUtils.getLoader(customizationState),
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
+          isFullWidth: customizationState?.hasFullWidth,
         ),
       );
     } else {
@@ -157,19 +158,20 @@ class _ButtonDemoState extends State<_ButtonDemo> {
               appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
               loader: ButtonCustomizationUtils.getLoader(customizationState),
               onPressed: customizationState?.hasEnabled == true ? () {} : null,
+              isFullWidth: customizationState?.hasFullWidth,
             ),
           ),
           ThemeBox(
-            themeContract: themeController!.currentTheme,
-            themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
-            child: OudsButton(
-              label: ButtonCustomizationUtils.getText(customizationState),
-              icon: ButtonCustomizationUtils.getIcon(customizationState, themeController!),
-              appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
-              loader: ButtonCustomizationUtils.getLoader(customizationState),
-              onPressed: customizationState?.hasEnabled == true ? () {} : null,
-            )
-          )
+              themeContract: themeController!.currentTheme,
+              themeMode: themeController!.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
+              child: OudsButton(
+                label: ButtonCustomizationUtils.getText(customizationState),
+                icon: ButtonCustomizationUtils.getIcon(customizationState, themeController!),
+                appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
+                loader: ButtonCustomizationUtils.getLoader(customizationState),
+                onPressed: customizationState?.hasEnabled == true ? () {} : null,
+                isFullWidth: customizationState?.hasFullWidth,
+              ))
         ],
       );
     }
@@ -224,6 +226,13 @@ class _CustomizationContentState extends State<_CustomizationContent> {
                   : (value) {
                       customizationState.hasEnabled = value;
                     },
+        ),
+        CustomizableSwitch(
+          title: context.l10n.app_components_button_fullWidth_label,
+          value: customizationState.hasFullWidth,
+          onChanged: (value) {
+            customizationState.hasFullWidth = value;
+          },
         ),
         CustomizableSwitch(
           title: context.l10n.app_components_common_onColoredBackground_label,

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Let `Button` takes the screen full width ([#577](https://github.com/Orange-OpenSource/ouds-flutter/issues/577))
 
 ### Fixed
+- [Library] Keyboard focus is not visible on `button` component ([#473](https://github.com/Orange-OpenSource/ouds-flutter/issues/473))
 - [Library] `Button`, `Chip`, `Link`, `Tag` components have text overflow ([#552](https://github.com/Orange-OpenSource/ouds-flutter/issues/552))
 - [Tool] Unsupported operation Web for ouds libs and demo app ([#559](https://github.com/Orange-OpenSource/ouds-flutter/issues/559))
 - [Library] Add a hint to explain how to interact with `input fields` (text, password, pin-code) ([#495](https://github.com/Orange-OpenSource/ouds-flutter/issues/495))

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Create component - `Bottom Navigation` ([#90](https://github.com/Orange-OpenSource/ouds-flutter/issues/90))
 
 ### Changed
+- [Library] Let `Button` takes the screen full width ([#577](https://github.com/Orange-OpenSource/ouds-flutter/issues/577))
 
 ### Fixed
 - [Library] `Button`, `Chip`, `Link`, `Tag` components have text overflow ([#552](https://github.com/Orange-OpenSource/ouds-flutter/issues/552))

--- a/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
@@ -40,11 +40,30 @@ class OudsButtonBackgroundModifier {
           return _getHoverColor(context, appearance);
         } else if (states.contains(WidgetState.disabled)) {
           return _getDisabledColor(context, appearance);
+        } else if (states.contains(WidgetState.focused)) {
+          return _getFocusedColor(context, appearance);
         }
 
         return _getEnabledColor(context, appearance);
       },
     );
+  }
+
+  static Color? _getFocusedColor(BuildContext context, OudsButtonAppearance appearance) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (appearance) {
+      case OudsButtonAppearance.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongFocus : theme.colorScheme(context).actionFocus;
+      case OudsButtonAppearance.brand:
+        return theme.componentsTokens(context).button.colorBgBrandFocus;
+      case OudsButtonAppearance.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgMinimalFocus : theme.componentsTokens(context).button.colorBgMinimalFocus;
+      case OudsButtonAppearance.negative:
+        return theme.colorScheme(context).actionNegativeFocus;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultFocus : theme.componentsTokens(context).button.colorBgDefaultFocus;
+    }
   }
 
   static Color? _getEnabledColor(BuildContext context, OudsButtonAppearance appearance) {

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -38,10 +38,32 @@ class OudsButtonBorderModifier {
           return _getHoverBorderColor(context, appearance);
         } else if (states.contains(WidgetState.disabled)) {
           return _getDisabledBorderColor(context, appearance);
+        } else if (states.contains(WidgetState.focused)) {
+          return _getFocusedBorderColor(context, appearance);
         }
         return _getEnabledBorderColor(context, appearance);
       },
     );
+  }
+
+  static BorderSide _getFocusedBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (appearance) {
+      case OudsButtonAppearance.strong:
+        return BorderSide.none;
+      case OudsButtonAppearance.brand:
+        return BorderSide.none;
+      case OudsButtonAppearance.minimal:
+        return BorderSide.none;
+      case OudsButtonAppearance.negative:
+        return BorderSide.none;
+      default:
+        return BorderSide(
+          color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultFocus : theme.componentsTokens(context).button.colorBorderDefaultFocus,
+          width: onColoredSurface ? theme.componentsTokens(context).button.borderWidthDefaultInteractionMono : theme.componentsTokens(context).button.borderWidthDefaultInteraction,
+        );
+    }
   }
 
   static BorderSide _getEnabledBorderColor(BuildContext context, OudsButtonAppearance appearance) {
@@ -127,6 +149,17 @@ class OudsButtonBorderModifier {
         return BorderRadius.circular(button.borderRadiusRounded);
       case false:
         return BorderRadius.circular(button.borderRadiusDefault);
+    }
+  }
+
+  static double getDoubleRadiusFocus(BuildContext context) {
+    final button = OudsTheme.of(context).componentsTokens(context).button;
+    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
+    switch (buttonRounded) {
+      case true:
+        return button.borderRadiusRounded;
+      case false:
+        return button.borderRadiusDefault;
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_control_state.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_control_state.dart
@@ -17,6 +17,7 @@ library;
 enum OudsButtonControlState {
   enabled, // The button is enabled and interactive.
   hovered, // The cursor is over the button.
+  focused, // The button has keyboard focus (focus highlight).
   pressed, // The button is being pressed.
   disabled, // The button is disabled and non-interactive.
   loading,
@@ -28,6 +29,7 @@ class OudsButtonControlStateDeterminer {
   final bool enabled;
   final bool isHovered;
   final bool isPressed;
+  final bool isFocused;
   final bool isLoading;
 
   /// Constructor to initialize the button state.
@@ -36,6 +38,7 @@ class OudsButtonControlStateDeterminer {
     required this.enabled,
     this.isHovered = false,
     this.isPressed = false,
+    this.isFocused = false,
     this.isLoading = false,
   });
 
@@ -43,9 +46,10 @@ class OudsButtonControlStateDeterminer {
   /// Returns a value from the OudsButtonControlState enum.
   OudsButtonControlState determineControlState() {
     if (!enabled) return OudsButtonControlState.disabled;
-    if (isPressed) return OudsButtonControlState.pressed;
-    if (isHovered) return OudsButtonControlState.hovered;
     if (isLoading) return OudsButtonControlState.loading;
+    if (isPressed) return OudsButtonControlState.pressed;
+    if (isFocused) return OudsButtonControlState.focused;
+    if (isHovered) return OudsButtonControlState.hovered;
     return OudsButtonControlState.enabled;
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
@@ -40,10 +40,29 @@ class OudsButtonForegroundModifier {
           return _getHoverForegroundColor(context, appearance);
         } else if (states.contains(WidgetState.disabled)) {
           return _getDisabledForegroundColor(context, appearance);
+        } else if (states.contains(WidgetState.focused)) {
+          return _getFocusedForegroundColor(context, appearance);
         }
         return _getEnabledForegroundColor(context, appearance);
       },
     );
+  }
+
+  static Color _getFocusedForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (appearance) {
+      case OudsButtonAppearance.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongFocus : theme.colorScheme(context).contentOnActionFocus;
+      case OudsButtonAppearance.brand:
+        return theme.componentsTokens(context).button.colorContentBrandFocus;
+      case OudsButtonAppearance.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalFocus : theme.componentsTokens(context).button.colorContentMinimalFocus;
+      case OudsButtonAppearance.negative:
+        return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultFocus : theme.componentsTokens(context).button.colorContentDefaultFocus;
+    }
   }
 
   static Color _getEnabledForegroundColor(BuildContext context, OudsButtonAppearance appearance) {

--- a/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
@@ -39,8 +39,28 @@ class OudsButtonIconModifier {
         return _getPressedIconColor(context, appearance);
       case OudsButtonControlState.disabled:
         return _getDisabledIconColor(context, appearance);
+      case OudsButtonControlState.focused:
+        return _getFocusedIconColor(context, appearance);
       case OudsButtonControlState.loading:
         return OudsButtonLoadingModifier.getColorToken(context, appearance);
+    }
+  }
+
+  /// Private static method to get the icon color when the button is enabled.
+  static Color _getFocusedIconColor(BuildContext context, OudsButtonAppearance appearance) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    switch (appearance) {
+      case OudsButtonAppearance.strong:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongFocus : theme.colorScheme(context).contentOnActionFocus;
+      case OudsButtonAppearance.brand:
+        return theme.componentsTokens(context).button.colorContentBrandFocus;
+      case OudsButtonAppearance.minimal:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalFocus : theme.componentsTokens(context).button.colorContentMinimalFocus;
+      case OudsButtonAppearance.negative:
+        return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
+      default:
+        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultFocus : theme.componentsTokens(context).button.colorContentDefaultFocus;
     }
   }
 

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -68,7 +68,6 @@ enum OudsButtonLayout {
 /// - [label]: Label displayed in the button which describes the button action. Use action verbs or phrases to tell the user what will happen next.
 /// - [icon]: Icon displayed in the button. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
 /// - [onPressed]: Callback invoked when the button is clicked.
-///
 ///   Controls the enabled state of the button when [loader] is equal to null.
 ///   When `false`, this button will not be clickable. Has no effect when [loader] is not null.
 /// - [loader]: An optional loading progress indicator displayed in the button to indicate an ongoing operation.
@@ -77,6 +76,7 @@ enum OudsButtonLayout {
 ///   To create the widget with an asset from a package, the [package] argument
 ///   must be provided. For instance, suppose a package called `my_icons` has
 ///   `icons/heart.svg` .
+/// - [isFullWidth]: Flag to let button take all the screen width, set to *false* by default.
 ///
 /// ### You can use [OudsButton] component in your project, customizing parameters as needed :
 ///
@@ -87,6 +87,7 @@ enum OudsButtonLayout {
 ///
 /// ```dart
 /// OudsButton(
+///       isFullWidth: false,
 ///       label: 'Button',
 ///       appearance: OudsButtonAppearance.defaultAppearance,
 ///       onPressed: () {
@@ -99,6 +100,7 @@ enum OudsButtonLayout {
 /// This is the Loading layout of the component.
 ///
 /// OudsButton(
+///       isFullWidth: false,
 ///       label: 'Button',
 ///       loader: Loader(progress: null),
 ///       appearance: OudsButtonAppearance.defaultAppearance
@@ -116,6 +118,7 @@ class OudsButton extends StatefulWidget {
   final Loader? loader;
   final OudsButtonAppearance appearance;
   final String? package;
+  final bool? isFullWidth;
 
   const OudsButton({
     super.key,
@@ -125,6 +128,7 @@ class OudsButton extends StatefulWidget {
     this.loader,
     required this.appearance,
     this.package,
+    this.isFullWidth = false,
   });
 
   @override
@@ -208,7 +212,7 @@ class _OudsButtonState extends State<OudsButton> {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
     switch (buttonState) {
       case OudsButtonControlState.loading:
-        return Semantics(
+        final buttonIconAndText = Semantics(
           label: OudsLocalizations.of(context)?.core_common_loading_a11y,
           enabled: false,
           button: true,
@@ -248,8 +252,9 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonIconAndText);
       default:
-        return MouseRegion(
+        final buttonIconAndText = MouseRegion(
           onEnter: (_) => setState(() => _isHovered = true),
           onExit: (_) => setState(() => _isHovered = false),
           child: GestureDetector(
@@ -291,13 +296,14 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonIconAndText);
     }
   }
 
   Widget _buildButtonIconOnly(BuildContext context, OudsButtonControlState buttonState) {
     switch (buttonState) {
       case OudsButtonControlState.loading:
-        return Semantics(
+        final buttonIconOnly = Semantics(
           label: OudsLocalizations.of(context)?.core_common_loading_a11y,
           enabled: false,
           button: true,
@@ -316,8 +322,9 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonIconOnly);
       default:
-        return MouseRegion(
+        final buttonIconOnly = MouseRegion(
           onEnter: (_) => setState(() => _isHovered = true),
           onExit: (_) => setState(() => _isHovered = false),
           child: GestureDetector(
@@ -337,6 +344,7 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonIconOnly);
     }
   }
 
@@ -344,7 +352,7 @@ class _OudsButtonState extends State<OudsButton> {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
     switch (buttonState) {
       case OudsButtonControlState.loading:
-        return Semantics(
+        final buttonTextOnly = Semantics(
           label: OudsLocalizations.of(context)?.core_common_loading_a11y,
           enabled: false,
           button: true,
@@ -367,8 +375,9 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonTextOnly);
       default:
-        return ClipRRect(
+        final buttonTextOnly = ClipRRect(
           borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
           child: OutlinedButton(
             style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout),
@@ -379,6 +388,7 @@ class _OudsButtonState extends State<OudsButton> {
             ),
           ),
         );
+        return _wrapFullWidth(buttonTextOnly);
     }
   }
 
@@ -395,6 +405,21 @@ class _OudsButtonState extends State<OudsButton> {
         ),
       );
     }
+  }
+
+  /// Expands the button to fill the available horizontal space when [widget.isFullWidth] is true.
+  ///
+  /// When `isFullWidth` is `true`, the returned widget wraps [child] in a [SizedBox] with
+  /// `width: double.infinity`, allowing the button to stretch to the maximum width allowed by
+  /// its parent constraints. When `isFullWidth` is `false` (default), [child] is returned as-is.
+  Widget _wrapFullWidth(Widget child) {
+    if (widget.isFullWidth == true) {
+      return SizedBox(
+        width: double.infinity,
+        child: widget.isFullWidth == false ? Center(child: child) : child,
+      );
+    }
+    return child;
   }
 
   Widget _buildIcon(

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -15,10 +15,12 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_border_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_icon_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
+import 'package:ouds_core/components/utilities/focus_container.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
@@ -162,6 +164,32 @@ class _OudsButtonState extends State<OudsButton> {
   bool _isHovered = false;
   bool _isPressed = false;
 
+  // Tracks keyboard focus highlight to make focus visible when navigating with a keyboard.
+  bool _isFocused = false;
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+    _focusNode.addListener(() {
+      setState(() {
+        _handleFocusChange(_focusNode.hasFocus);
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChange(bool focus) {
+    if (widget.onPressed == null) _isFocused = false; // Ignore focus changes if disabled
+    setState(() => _isFocused = focus);
+  }
+
   void _handlePressed(VoidCallback? callback) {
     setState(() {
       _isPressed = true;
@@ -186,9 +214,11 @@ class _OudsButtonState extends State<OudsButton> {
       enabled: widget.onPressed != null,
       isPressed: _isPressed,
       isHovered: _isHovered,
+      isFocused: _isFocused,
       isLoading: widget.loader != null,
     );
     final buttonState = buttonStateDeterminer.determineControlState();
+    final borderTokens = OudsTheme.of(context).borderTokens;
 
     try {
       if (widget.appearance == OudsButtonAppearance.negative && OudsTheme.isOnColoredSurfaceOf(context)) {
@@ -198,6 +228,24 @@ class _OudsButtonState extends State<OudsButton> {
     } catch (e) {
       debugPrint("Warning: ${e.toString()}");
     }
+
+    return FocusContainer(
+      color: OudsTheme.of(context).colorScheme(context).borderFocus,
+      strokeWidth: borderTokens.widthFocus,
+      borderRadius: OudsButtonBorderModifier.getDoubleRadiusFocus(context),
+      alignment: FocusAlignment.center,
+      isFocused: _isFocused,
+      child: _buildLayout(
+        context,
+        buttonState,
+      ),
+    );
+  }
+
+  Widget _buildLayout(
+    BuildContext context,
+    OudsButtonControlState buttonState,
+  ) {
     switch (widget.layout) {
       case OudsButtonLayout.iconOnly:
         return _buildButtonIconOnly(context, buttonState);
@@ -261,35 +309,33 @@ class _OudsButtonState extends State<OudsButton> {
             onTapDown: (_) => setState(() => _isPressed = true),
             onTapUp: (_) => setState(() => _isPressed = false),
             onTapCancel: () => setState(() => _isPressed = false),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
-              child: Semantics(
-                label: widget.label ?? "",
-                button: true,
-                child: ExcludeSemantics(
-                  child: OutlinedButton(
-                    onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-                    style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout, buttonState: buttonState),
-                    child: Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            _buildIcon(context, widget.icon!, widget.appearance, widget.layout, buttonState),
-                            SizedBox(
-                              width: buttonToken.spaceColumnGapIcon,
+            child: Semantics(
+              label: widget.label ?? "",
+              button: true,
+              child: ExcludeSemantics(
+                child: OutlinedButton(
+                  focusNode: _focusNode,
+                  onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
+                  style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout, buttonState: buttonState),
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _buildIcon(context, widget.icon!, widget.appearance, widget.layout, buttonState),
+                          SizedBox(
+                            width: buttonToken.spaceColumnGapIcon,
+                          ),
+                          Flexible(
+                            child: Text(
+                              widget.label ?? "",
+                              textAlign: TextAlign.center,
                             ),
-                            Flexible(
-                              child: Text(
-                                widget.label ?? "",
-                                textAlign: TextAlign.center,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
               ),
@@ -336,6 +382,7 @@ class _OudsButtonState extends State<OudsButton> {
               button: true,
               child: ExcludeSemantics(
                 child: IconButton(
+                  focusNode: _focusNode,
                   style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout, buttonState: buttonState),
                   onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
                   icon: _buildIcon(context, widget.icon!, widget.appearance, widget.layout, buttonState),
@@ -349,7 +396,6 @@ class _OudsButtonState extends State<OudsButton> {
   }
 
   Widget _buildButtonTextOnly(BuildContext context, OudsButtonControlState buttonState) {
-    final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
     switch (buttonState) {
       case OudsButtonControlState.loading:
         final buttonTextOnly = Semantics(
@@ -377,15 +423,13 @@ class _OudsButtonState extends State<OudsButton> {
         );
         return _wrapFullWidth(buttonTextOnly);
       default:
-        final buttonTextOnly = ClipRRect(
-          borderRadius: BorderRadius.circular(buttonToken.borderRadiusDefault),
-          child: OutlinedButton(
-            style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout),
-            onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
-            child: Text(
-              widget.label ?? "",
-              textAlign: TextAlign.center,
-            ),
+        final buttonTextOnly = OutlinedButton(
+          focusNode: _focusNode,
+          style: OudsButtonStyleModifier.buildButtonStyle(context, appearance: widget.appearance, layout: widget.layout),
+          onPressed: widget.onPressed == null ? null : () => _handlePressed(widget.onPressed),
+          child: Text(
+            widget.label ?? "",
+            textAlign: TextAlign.center,
           ),
         );
         return _wrapFullWidth(buttonTextOnly);

--- a/ouds_core/lib/components/utilities/focus_container.dart
+++ b/ouds_core/lib/components/utilities/focus_container.dart
@@ -1,0 +1,154 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+/// @nodoc
+library;
+
+import 'package:flutter/material.dart';
+import 'package:ouds_core/components/common/OudsBorder.dart';
+import 'package:ouds_theme_contract/ouds_theme.dart';
+
+/// Controls how the focus ring stroke is positioned relative to the widget bounds.
+enum FocusAlignment {
+  /// The stroke is fully inside the widget bounds.
+  inside,
+
+  /// The stroke is centered on the widget bounds (half inside, half outside).
+  center,
+
+  /// The stroke is fully outside the widget bounds.
+  outside,
+}
+
+/// A [CustomPainter] that draws a rounded-rectangle focus ring.
+///
+/// The ring is drawn using a stroke of [strokeWidth] and rounded corners
+/// defined by [borderRadius]. The ring position depends on [alignment]:
+/// - [FocusAlignment.inside] deflates the rect by half the stroke width.
+/// - [FocusAlignment.center] draws on the original rect.
+/// - [FocusAlignment.outside] inflates the rect by half the stroke width.
+class FocusContainerPainter extends CustomPainter {
+  final Color color;
+  final double strokeWidth;
+  final double borderRadius;
+  final FocusAlignment alignment;
+
+  FocusContainerPainter({
+    required this.color,
+    required this.strokeWidth,
+    required this.borderRadius,
+    this.alignment = FocusAlignment.center,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..color = color
+      ..isAntiAlias = true;
+
+    Rect baseRect = Offset.zero & size;
+    RRect rrect = RRect.fromRectAndRadius(baseRect, Radius.circular(borderRadius));
+
+    final half = strokeWidth / 2;
+    if (alignment == FocusAlignment.outside) {
+      rrect = rrect.inflate(half);
+    } else if (alignment == FocusAlignment.inside) {
+      rrect = rrect.deflate(half);
+    }
+    canvas.drawRRect(rrect, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant FocusContainerPainter oldDelegate) {
+    return oldDelegate.color != color || oldDelegate.strokeWidth != strokeWidth || oldDelegate.borderRadius != borderRadius || oldDelegate.alignment != alignment;
+  }
+}
+
+/// Wraps [child] with an optional focus ring and an optional inset border.
+///
+/// When [isFocused] is true, a focus ring is painted using [CustomPaint]
+/// inside a [Stack]. The ring uses theme tokens (focus border color/width)
+/// and can be visually aligned via [alignment].
+///
+/// This widget is designed to be used by interactive components to make
+/// keyboard focus visible (for example when navigating with Tab).
+class FocusContainer extends StatelessWidget {
+  /// The content widget.
+  final Widget child;
+
+  /// Optional ring color (defaults to transparent).
+  ///
+  /// Note: the current implementation uses theme colors for the painted ring.
+  final Color color;
+
+  /// The stroke width used for the focus ring.
+  ///
+  /// Note: the current implementation uses theme tokens for the painted ring.
+  final double strokeWidth;
+
+  /// Corner radius used for the focus ring and the inset border.
+  final double borderRadius;
+
+  /// Focus ring alignment relative to the widget bounds.
+  final FocusAlignment alignment;
+
+  /// Whether the focus ring should be visible.
+  final bool isFocused;
+
+  const FocusContainer({
+    super.key,
+    required this.child,
+    this.color = Colors.transparent,
+    this.strokeWidth = 5,
+    this.borderRadius = 8,
+    this.alignment = FocusAlignment.center,
+    this.isFocused = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // When the container is drawn "outside", allow it to overflow the child's bounds
+    // (Stack.clipBehavior = Clip.none) by using a negative inset.
+    //final inset = alignment == FocusAlignment.outside ? -strokeWidth / 2 : 0.0;
+    final borderTokens = OudsTheme.of(context).borderTokens;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        if (isFocused)
+          Positioned.fill(
+            child: CustomPaint(
+              painter: FocusContainerPainter(
+                color: color,
+                strokeWidth: borderTokens.widthFocus,
+                borderRadius: borderRadius,
+                alignment: FocusAlignment.center,
+              ),
+            ),
+          ),
+        // The child should keep the same visual border radius via the inset border decoration.
+        Container(
+          decoration: BoxDecoration(
+            border: OudsBorder().borderAll(
+              color: isFocused ? OudsTheme.of(context).colorScheme(context).borderFocusInset : Colors.transparent,
+              width: borderTokens.widthFocusInset,
+            ),
+            borderRadius: BorderRadius.circular(borderRadius),
+          ),
+          child: child,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

- [x] #577 
closes #473

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [ ] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [ ] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
