### PR TITLE
feat: resolve notnull check in different components

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Tool] Update `Flutter` to 3.38.0 and `Dart` Version to 3.10.8  ([#572](https://github.com/Orange-OpenSource/ouds-flutter/issues/572))
 
 ### Fixed
+- [DemoApp][Library] remove `Not Null` check in components ([#587](https://github.com/Orange-OpenSource/ouds-flutter/issues/587))
 - [Library] Missing tokens in the token presentation pages ([#554](https://github.com/Orange-OpenSource/ouds-flutter/issues/554))
 - [Library] Keyboard focus is not visible on `button` component ([#473](https://github.com/Orange-OpenSource/ouds-flutter/issues/473))
 - [DemoApp] Activated tab `Navigation bar` is not highlighted ([#384](https://github.com/Orange-OpenSource/ouds-flutter/issues/384))

--- a/app/lib/ui/components/pin_code_input/pin_code_input_code_generator.dart
+++ b/app/lib/ui/components/pin_code_input/pin_code_input_code_generator.dart
@@ -14,7 +14,6 @@ import 'package:flutter/material.dart';
 import 'package:ouds_flutter_demo/ui/components/pin_code_input/pin_code_input_customization.dart';
 import 'package:ouds_flutter_demo/ui/components/pin_code_input/pin_code_input_customization_utils.dart';
 
-
 class PinCodeInputCodeGenerator {
   static String updateCode(BuildContext context) {
     final PinCodeInputCustomizationState? state = PinCodeInputCustomization.of(context);
@@ -26,8 +25,7 @@ class PinCodeInputCodeGenerator {
     lines.add(" controllers: controllers,");
 
     if (state.hasHelperText && !state.hasError) {
-      lines.add(
-          ' helperText: "${PinCodeInputCustomizationUtils.getPinCodeHelperText(state)}",');
+      lines.add(' helperText: "${PinCodeInputCustomizationUtils.getPinCodeHelperText(state)}",');
     }
 
     if (state.hasError) {
@@ -43,12 +41,7 @@ class PinCodeInputCodeGenerator {
 
     final String decoration = _digitDecorationCode(state);
 
-    return [
-      "OudsPinCodeInput(",
-        ...lines,
-        decoration,
-      "),"
-    ].join("\n");
+    return ["OudsPinCodeInput(", ...lines, decoration, "),"].join("\n");
   }
 
   static String _digitDecorationCode(PinCodeInputCustomizationState state) {
@@ -57,10 +50,6 @@ class PinCodeInputCodeGenerator {
     if (state.pinCodePlaceholderText.isNotEmpty) {
       final hint = PinCodeInputCustomizationUtils.getPinCodePlaceholderText(state);
       props.add(' hintText: "$hint",');
-    }
-
-    if (state.hasRoundedCorner) {
-      props.add(' roundedCorner: ${state.hasRoundedCorner},');
     }
 
     if (state.hasHiddenPassword) {

--- a/app/lib/ui/components/pin_code_input/pin_code_input_customization.dart
+++ b/app/lib/ui/components/pin_code_input/pin_code_input_customization.dart
@@ -34,29 +34,19 @@ class PinCodeInputCustomization extends StatefulWidget {
 
 /// TextInput customization state management
 class PinCodeInputCustomizationState extends CustomizationWidgetState<PinCodeInputCustomization> {
-  late final ErrorState errorState;
-  late final HiddenPasswordState hiddenPasswordState;
+  // Initialize states that don't need context immediately (inline)
+  late final ErrorState errorState = ErrorState(setState);
+  late final HiddenPasswordState hiddenPasswordState = HiddenPasswordState(setState);
+  late final PinCodeHasHelperTextState pinCodeHasHelperTextState = PinCodeHasHelperTextState(setState);
+  late final PinCodeErrorTextState pinCodeErrorTextState = PinCodeErrorTextState(setState);
+  late final PinCodePlaceholderTextState pinCodePlaceholderTextState = PinCodePlaceholderTextState(setState);
+  late final RoundedCornerState roundedCornerState = RoundedCornerState(setState);
+  late final OutlinedState outlinedState = OutlinedState(setState);
+  late final ConstrainedMaxWidthState constrainedMaxWidthState = ConstrainedMaxWidthState(setState);
+
+  // These need context, so they stay as late fields
   late final PinCodeHelperTextState pinCodeHelperTextState;
   late final PinCodeLengthState pinCodeLengthState;
-  late final PinCodeHasHelperTextState pinCodeHasHelperTextState;
-  late final PinCodeErrorTextState pinCodeErrorTextState;
-  late final PinCodePlaceholderTextState pinCodePlaceholderTextState;
-  late final RoundedCornerState roundedCornerState;
-  late final OutlinedState outlinedState;
-  late final ConstrainedMaxWidthState constrainedMaxWidthState;
-
-  @override
-  void initState() {
-    super.initState();
-    errorState = ErrorState(setState);
-    hiddenPasswordState = HiddenPasswordState(setState);
-    pinCodeHasHelperTextState = PinCodeHasHelperTextState(setState);
-    pinCodeErrorTextState = PinCodeErrorTextState(setState);
-    pinCodePlaceholderTextState = PinCodePlaceholderTextState(setState);
-    roundedCornerState = RoundedCornerState(setState);
-    outlinedState = OutlinedState(setState);
-    constrainedMaxWidthState = ConstrainedMaxWidthState(setState);
-  }
 
   @override
   void didChangeDependencies() {

--- a/app/lib/ui/components/pin_code_input/pin_code_input_demo_screen.dart
+++ b/app/lib/ui/components/pin_code_input/pin_code_input_demo_screen.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/pin_code_input/digit_input/ouds_digit_input.dart';
@@ -117,12 +116,12 @@ class _PinCodeInputDemoState extends State<_PinCodeInputDemo> {
   @override
   Widget build(BuildContext context) {
     final customizationState = PinCodeInputCustomization.of(context)!;
+    final themeController = Provider.of<ThemeController>(context, listen: true);
 
     for (int i = 0; i < PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object).digits; i++) {
       controllers.add(TextEditingController());
     }
 
-    final themeController = Provider.of<ThemeController>(context, listen: true);
     // Adding post-frame callback to update theme based on customization state
     WidgetsBinding.instance.addPostFrameCallback((_) {
       themeController.setOnBorderRadiusTextInputState(customizationState.hasRoundedCorner);
@@ -137,58 +136,58 @@ class _PinCodeInputDemoState extends State<_PinCodeInputDemo> {
           themeContract: themeController.currentTheme,
           themeMode: themeController.isInverseDarkTheme ? ThemeMode.light : ThemeMode.dark,
           child: OudsPinCodeInput(
-              controllers: controllers,
-              helperText: customizationState.hasHelperText && customizationState.pinCodeHelperText.isNotEmpty ? PinCodeInputCustomizationUtils.getPinCodeHelperText(customizationState) : null,
-              length: getLength,
-              errorText: customizationState.hasError ? PinCodeInputCustomizationUtils.getPinCodeErrorText(customizationState) : null,
-              digitInputDecoration: OudsDigitInputDecoration(
-                hintText: PinCodeInputCustomizationUtils.getPinCodePlaceholderText(customizationState),
-                roundedCorner: customizationState.hasRoundedCorner,
-                hiddenPassword: customizationState.hasHiddenPassword,
-                isOutlined: customizationState.hasOutlined,
-                constrainedMaxWidth: customizationState.hasConstrainedMaxWidth ? true : false,
-              ),
-              onEditingComplete: (value) async {
-                final errorLabel = context.l10n.app_components_pinCodeInput_error_label;
-                final verificationErrorLabel = context.l10n.app_components_pinCodeInput_verification_error_label;
-                await _handleCompleted(context, value, PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object).digits, customizationState, errorLabel, verificationErrorLabel);
-              },
-              onChanged: (value) {
-                if (value.isEmpty || value.length < getLength.digits) {
-                  customizationState.hasError = false;
-                  return;
-                }
-              },
+            controllers: controllers,
+            helperText: customizationState.hasHelperText && customizationState.pinCodeHelperText.isNotEmpty ? PinCodeInputCustomizationUtils.getPinCodeHelperText(customizationState) : null,
+            length: getLength,
+            errorText: customizationState.hasError ? PinCodeInputCustomizationUtils.getPinCodeErrorText(customizationState) : null,
+            digitInputDecoration: OudsDigitInputDecoration(
+              hintText: PinCodeInputCustomizationUtils.getPinCodePlaceholderText(customizationState),
+              hiddenPassword: customizationState.hasHiddenPassword,
+              isOutlined: customizationState.hasOutlined,
+              constrainedMaxWidth: customizationState.hasConstrainedMaxWidth ? true : false,
             ),
+            onEditingComplete: (value) async {
+              final errorLabel = context.l10n.app_components_pinCodeInput_error_label;
+              final verificationErrorLabel = context.l10n.app_components_pinCodeInput_verification_error_label;
+              await _handleCompleted(
+                  context, value, PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object).digits, customizationState, errorLabel, verificationErrorLabel);
+            },
+            onChanged: (value) {
+              if (value.isEmpty || value.length < getLength.digits) {
+                customizationState.hasError = false;
+                return;
+              }
+            },
+          ),
         ),
         ThemeBox(
           hasConstrainedMaxWidthOption: true,
           themeContract: themeController.currentTheme,
           themeMode: themeController.isInverseDarkTheme ? ThemeMode.dark : ThemeMode.light,
           child: OudsPinCodeInput(
-                controllers: controllers,
-                helperText: customizationState.hasHelperText && customizationState.pinCodeHelperText.isNotEmpty ? PinCodeInputCustomizationUtils.getPinCodeHelperText(customizationState) : null,
-                length: PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object),
-                errorText: customizationState.hasError ? PinCodeInputCustomizationUtils.getPinCodeErrorText(customizationState) : null,
-                digitInputDecoration: OudsDigitInputDecoration(
-                  hintText: PinCodeInputCustomizationUtils.getPinCodePlaceholderText(customizationState),
-                  roundedCorner: customizationState.hasRoundedCorner,
-                  hiddenPassword: customizationState.hasHiddenPassword,
-                  isOutlined: customizationState.hasOutlined,
-                  constrainedMaxWidth: customizationState.hasConstrainedMaxWidth ? true : false,
-                ),
-                onEditingComplete: (value) async {
-                  final errorLabel = context.l10n.app_components_pinCodeInput_error_label;
-                  final verificationErrorLabel = context.l10n.app_components_pinCodeInput_verification_error_label;
-                  await _handleCompleted(context, value, PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object).digits, customizationState, errorLabel, verificationErrorLabel);
-                },
-                onChanged: (value) {
-                  if (value.isEmpty || value.length < getLength.digits) {
-                    customizationState.hasError = false;
-                    return;
-                  }
-                },
-              ),
+            controllers: controllers,
+            helperText: customizationState.hasHelperText && customizationState.pinCodeHelperText.isNotEmpty ? PinCodeInputCustomizationUtils.getPinCodeHelperText(customizationState) : null,
+            length: PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object),
+            errorText: customizationState.hasError ? PinCodeInputCustomizationUtils.getPinCodeErrorText(customizationState) : null,
+            digitInputDecoration: OudsDigitInputDecoration(
+              hintText: PinCodeInputCustomizationUtils.getPinCodePlaceholderText(customizationState),
+              hiddenPassword: customizationState.hasHiddenPassword,
+              isOutlined: customizationState.hasOutlined,
+              constrainedMaxWidth: customizationState.hasConstrainedMaxWidth ? true : false,
+            ),
+            onEditingComplete: (value) async {
+              final errorLabel = context.l10n.app_components_pinCodeInput_error_label;
+              final verificationErrorLabel = context.l10n.app_components_pinCodeInput_verification_error_label;
+              await _handleCompleted(
+                  context, value, PinCodeInputCustomizationUtils.getLength(customizationState.selectedPinCodeLength as Object).digits, customizationState, errorLabel, verificationErrorLabel);
+            },
+            onChanged: (value) {
+              if (value.isEmpty || value.length < getLength.digits) {
+                customizationState.hasError = false;
+                return;
+              }
+            },
+          ),
         ),
         SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedSmall),
       ],

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Let `Button` takes the screen full width ([#577](https://github.com/Orange-OpenSource/ouds-flutter/issues/577))
 
 ### Fixed
+- [Library] remove `Not Null` check in components ([#587](https://github.com/Orange-OpenSource/ouds-flutter/issues/587))
 - [Library] Keyboard focus is not visible on `button` component ([#473](https://github.com/Orange-OpenSource/ouds-flutter/issues/473))
 - [Library] `Button`, `Chip`, `Link`, `Tag` components have text overflow ([#552](https://github.com/Orange-OpenSource/ouds-flutter/issues/552))
 - [Tool] Unsupported operation Web for ouds libs and demo app ([#559](https://github.com/Orange-OpenSource/ouds-flutter/issues/559))

--- a/ouds_core/lib/components/chip/ouds_filter_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_filter_chip.dart
@@ -167,15 +167,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     return _buildFilterChip(context, chipBorderModifier, chipTextColorModifier, chipBackgroundColorModifier, chipIconColorModifier, chipState, isDisabled);
   }
 
-  Widget _buildFilterChip(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier,
-      OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildFilterChip(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
+      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final borderTokens = OudsTheme.of(context).borderTokens;
     final l10n = OudsLocalizations.of(context);
     final enabled = widget.onSelected != null;
-    String semanticsLabel = '${widget.selected == true ? l10n!.core_filterChip_selected_a11y : l10n!.core_filterChip_unselected_a11y},'
+    String semanticsLabel = '${widget.selected == true ? l10n?.core_filterChip_selected_a11y : l10n?.core_filterChip_unselected_a11y},'
         ' ${widget.label ?? ""}, '
-        '${enabled && widget.selected == true ? l10n.core_filterChip_hint_unselected_a11y : enabled && widget.selected == false ? l10n.core_filterChip_hint_selected_a11y : ''}';
+        '${enabled && widget.selected == true ? l10n?.core_filterChip_hint_unselected_a11y : enabled && widget.selected == false ? l10n?.core_filterChip_hint_selected_a11y : ''}';
 
     return Semantics(
       enabled: enabled,
@@ -266,8 +266,8 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildIconOnly(
-      BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildIconOnly(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier,
+      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final theme = OudsTheme.of(context);
 
@@ -335,8 +335,8 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildIconAndText(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlIconColorModifier chipIconColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildIconAndText(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
+      OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
 
     return Stack(
@@ -418,8 +418,8 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildTextOnly(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier,
-      OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildTextOnly(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
+      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
 
     return Stack(
@@ -497,8 +497,8 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildLayout(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier,
-      OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildLayout(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier,
+      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlState chipState, bool isDisabled) {
     final l10n = OudsLocalizations.of(context);
 
     switch (widget.layout) {

--- a/ouds_core/lib/components/form_input/internal/modifier/ouds_form_input_border_modifier.dart
+++ b/ouds_core/lib/components/form_input/internal/modifier/ouds_form_input_border_modifier.dart
@@ -14,6 +14,7 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/form_input/internal/ouds_form_input_control_state.dart';
+import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// A class that provides the border color for the OudsTextInput based on its state and selection
@@ -147,9 +148,12 @@ class OudsFormFieldsBorderModifier {
 
   /// Static method to get the border radius for a text input based on the border parameter.
   /// Returns a [BorderRadius] object with the appropriate radius value.
-  BorderRadius getBorderRadius(BuildContext context, bool? border) {
+  BorderRadius getBorderRadius(BuildContext context) {
     final textInput = OudsTheme.of(context).componentsTokens(context).textInput;
-    switch (border!) {
+    // Check if rounded borders are enabled in the theme config
+    final rounded = OudsThemeConfigModel.of(context)?.textInput?.rounded ?? false;
+
+    switch (rounded) {
       case true:
         return BorderRadius.circular(textInput.borderRadiusRounded);
       case false:

--- a/ouds_core/lib/components/form_input/ouds_phone_number_input.dart
+++ b/ouds_core/lib/components/form_input/ouds_phone_number_input.dart
@@ -30,7 +30,6 @@ import 'package:ouds_core/components/form_input/internal/ouds_form_input_decorat
 import 'package:ouds_core/components/utilities/app_assets.dart';
 import 'package:ouds_core/components/utilities/input_utils.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
-import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_theme_contract/ouds_theme_contract.dart';
 import 'package:ouds_theme_contract/theme/tokens/components/ouds_textInput_tokens.dart';
@@ -250,9 +249,6 @@ class _OudsPhoneNumberInputState extends State<OudsPhoneNumberInput> {
     // Check if the input is currently showing an error
     final isError = widget.decoration.errorText != null;
 
-    // Check if rounded borders are enabled in the theme config
-    final isBorderRadius = OudsThemeConfigModel.of(context)?.textInput?.rounded;
-
     final l10n = OudsLocalizations.of(context);
 
     String? formattedNumber = "";
@@ -305,7 +301,7 @@ class _OudsPhoneNumberInputState extends State<OudsPhoneNumberInput> {
                 // Bottom border styling; full border if style is not default
                 border: inputTextBorderModifier.getBorder(state, isError, widget.decoration.outlined),
                 // Border radius if enabled in theme configuration
-                borderRadius: inputTextBorderModifier.getBorderRadius(context, isBorderRadius),
+                borderRadius: inputTextBorderModifier.getBorderRadius(context),
               ),
               child: ConstrainedBox(
                 // Minimum height constraint for the input container
@@ -401,8 +397,8 @@ class _OudsPhoneNumberInputState extends State<OudsPhoneNumberInput> {
   /// - Shows hint text if provided or if formattedNumber is available, styled accordingly.
   /// - Adds a prefix widget if prefix or country selector is present, styled appropriately.
   /// - Ensures the text field is dense for compact layout.
-  TextField _buildTextField(OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme, BuildContext context, OudsTextInputTokens textInput,
-      bool effectiveIsFocused, String formattedNumber, String limitedDigits) {
+  TextField _buildTextField(OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme,
+      BuildContext context, OudsTextInputTokens textInput, bool effectiveIsFocused, String formattedNumber, String limitedDigits) {
     return TextField(
       controller: widget.controller,
       cursorColor: inputTextTextModifier.getCursorTextColor(state, isError),
@@ -479,7 +475,9 @@ class _OudsPhoneNumberInputState extends State<OudsPhoneNumberInput> {
             : null,
 
         // Hint text widget, shown if hintText is provided
-        prefix: (widget.decoration.prefix != null || widget.countrySelector?.selectedCountry != null) && widget.decoration.labelText != null && widget.decoration.hasPrefix ? _buildPrefixText(context, state) : null,
+        prefix: (widget.decoration.prefix != null || widget.countrySelector?.selectedCountry != null) && widget.decoration.labelText != null && widget.decoration.hasPrefix
+            ? _buildPrefixText(context, state)
+            : null,
         isDense: true,
       ),
     );

--- a/ouds_core/lib/components/form_input/ouds_text_input.dart
+++ b/ouds_core/lib/components/form_input/ouds_text_input.dart
@@ -25,7 +25,6 @@ import 'package:ouds_core/components/link/ouds_link.dart';
 import 'package:ouds_core/components/utilities/app_assets.dart';
 import 'package:ouds_core/components/utilities/input_utils.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
-import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_theme_contract/ouds_theme_contract.dart';
 import 'package:ouds_theme_contract/theme/tokens/components/ouds_textInput_tokens.dart';
@@ -227,9 +226,6 @@ class _OudsTextInputState extends State<OudsTextField> {
     // Check if the input is currently showing an error
     final isError = widget.decoration.errorText != null;
 
-    // Check if rounded borders are enabled in the theme config
-    final isBorderRadius = OudsThemeConfigModel.of(context)?.textInput?.rounded;
-
     final l10n = OudsLocalizations.of(context);
 
     //needed for accessibility
@@ -262,7 +258,7 @@ class _OudsTextInputState extends State<OudsTextField> {
 
     return Semantics(
       label: semanticsValue,
-      hint:  l10n?.core_common_hint_a11y,
+      hint: l10n?.core_common_hint_a11y,
       value: isError ? l10n?.core_common_onError_a11y : null,
       focused: effectiveFocusNode != null,
       focusable: true,
@@ -284,7 +280,7 @@ class _OudsTextInputState extends State<OudsTextField> {
                 border: inputTextBorderModifier.getBorder(state, isError, widget.decoration.outlined),
 
                 // Border radius if enabled in theme configuration
-                borderRadius: inputTextBorderModifier.getBorderRadius(context, isBorderRadius),
+                borderRadius: inputTextBorderModifier.getBorderRadius(context),
               ),
               child: ConstrainedBox(
                 // Minimum height constraint for the input container
@@ -294,7 +290,9 @@ class _OudsTextInputState extends State<OudsTextField> {
                 child: Padding(
                   padding: EdgeInsetsGeometry.directional(
                     start: textInput.spacePaddingInlineDefault,
-                    end: (widget.decoration.suffixIcon != null || widget.decoration.errorText != null || widget.decoration.loader != null) ? textInput.spacePaddingInlineTrailingAction : textInput.spacePaddingInlineDefault,
+                    end: (widget.decoration.suffixIcon != null || widget.decoration.errorText != null || widget.decoration.loader != null)
+                        ? textInput.spacePaddingInlineTrailingAction
+                        : textInput.spacePaddingInlineDefault,
                     top: textInput.spacePaddingBlockDefault,
                     bottom: textInput.spacePaddingBlockDefault,
                   ),
@@ -329,7 +327,7 @@ class _OudsTextInputState extends State<OudsTextField> {
                       /// Center block: main text input
                       /// Wrap the TextField in Flexible to control its width
                       Flexible(
-                        flex: 2,// Allocates 2 parts of the available space
+                        flex: 2, // Allocates 2 parts of the available space
                         child: ExcludeSemantics(
                           child: Container(
                             alignment: Alignment.center,
@@ -341,6 +339,7 @@ class _OudsTextInputState extends State<OudsTextField> {
                           ),
                         ),
                       ),
+
                       /// Center-left: prefix text displayed even without label
                       /// Set a flexible to prevent text overflow
                       if (widget.decoration.suffix != null && widget.decoration.labelText == null && (widget.decoration.hintText != null || _isTyping)) ...[
@@ -362,7 +361,11 @@ class _OudsTextInputState extends State<OudsTextField> {
                       /// Right block: suffix icon container
                       Container(
                         alignment: Alignment.center,
-                        child: Semantics(label: widget.decoration.suffixIcon != null && widget.decoration.loader == false ? widget.trailingIconContentDescription : null, container: true, button: true, child: _buildSuffixIcon(context, state)),
+                        child: Semantics(
+                            label: widget.decoration.suffixIcon != null && widget.decoration.loader == false ? widget.trailingIconContentDescription : null,
+                            container: true,
+                            button: true,
+                            child: _buildSuffixIcon(context, state)),
                       ),
                     ],
                   ),
@@ -411,8 +414,8 @@ class _OudsTextInputState extends State<OudsTextField> {
   /// - Shows hint text if provided, styled according to theme.
   /// - Adds prefix and suffix widgets when specified, with proper styling and spacing.
   /// - Uses dense layout for compact appearance.
-  TextField _buildTextField(
-      OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme, BuildContext context, OudsTextInputTokens textInput, bool effectiveIsFocused) {
+  TextField _buildTextField(OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme,
+      BuildContext context, OudsTextInputTokens textInput, bool effectiveIsFocused) {
     return TextField(
       cursorColor: inputTextTextModifier.getCursorTextColor(state, isError),
       focusNode: effectiveFocusNode,
@@ -481,20 +484,20 @@ class _OudsTextInputState extends State<OudsTextField> {
         // Prefix widget displayed when prefix and labelText are both set
         // Set a maximum width to prevent text overflow
         prefix: widget.decoration.prefix != null && widget.decoration.labelText != null
-            ?  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          widget.decoration.prefix!,
-                          style: theme.typographyTokens.typeLabelDefaultLarge(context).copyWith(
-                                color: inputTextTextModifier.getSuffixPrefixTextColor(state),
-                              ),
-                        ),
-                      ),
-                      SizedBox(width: textInput.spaceColumnGapInlineText),
-                    ],
-            )
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Text(
+                      widget.decoration.prefix!,
+                      style: theme.typographyTokens.typeLabelDefaultLarge(context).copyWith(
+                            color: inputTextTextModifier.getSuffixPrefixTextColor(state),
+                          ),
+                    ),
+                  ),
+                  SizedBox(width: textInput.spaceColumnGapInlineText),
+                ],
+              )
             : null,
 
         // Override default constraints to better fit OUDS design
@@ -504,19 +507,19 @@ class _OudsTextInputState extends State<OudsTextField> {
         // Set a maximum width to prevent text overflow
         suffix: widget.decoration.suffix != null && widget.decoration.labelText != null
             ? Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(width: textInput.spaceColumnGapInlineText),
-                    Flexible(
-                      child: Text(
-                        widget.decoration.suffix!,
-                        style: theme.typographyTokens.typeLabelDefaultLarge(context).copyWith(
-                              color: inputTextTextModifier.getSuffixPrefixTextColor(state),
-                            ),
-                      ),
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(width: textInput.spaceColumnGapInlineText),
+                  Flexible(
+                    child: Text(
+                      widget.decoration.suffix!,
+                      style: theme.typographyTokens.typeLabelDefaultLarge(context).copyWith(
+                            color: inputTextTextModifier.getSuffixPrefixTextColor(state),
+                          ),
                     ),
-                  ],
-            )
+                  ),
+                ],
+              )
             : null,
         isDense: true,
       ),

--- a/ouds_core/lib/components/form_input/password_input/ouds_password_input.dart
+++ b/ouds_core/lib/components/form_input/password_input/ouds_password_input.dart
@@ -24,7 +24,6 @@ import 'package:ouds_core/components/form_input/password_input/ouds_password_inp
 import 'package:ouds_core/components/utilities/app_assets.dart';
 import 'package:ouds_core/components/utilities/input_utils.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
-import 'package:ouds_theme_contract/config/ouds_theme_config_model.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_theme_contract/ouds_theme_contract.dart';
 import 'package:ouds_theme_contract/theme/tokens/components/ouds_textInput_tokens.dart';
@@ -222,9 +221,6 @@ class _OudsPasswordInputState extends State<OudsPasswordInput> {
     // Check if the input is currently showing an error
     final isError = widget.decoration.errorText != null;
 
-    // Check if rounded borders are enabled in the theme config
-    final isBorderRadius = OudsThemeConfigModel.of(context)?.textInput?.rounded;
-
     final l10n = OudsLocalizations.of(context);
 
     final contentText = widget.controller?.text;
@@ -237,7 +233,7 @@ class _OudsPasswordInputState extends State<OudsPasswordInput> {
           "$prefixText $contentText, $helperText, "
           "${widget.enabled == false || widget.readOnly == true ? l10n?.core_common_disabled_a11y : ""}",
       value: isError ? l10n?.core_common_onError_a11y : null,
-      hint:  l10n?.core_common_hint_a11y,
+      hint: l10n?.core_common_hint_a11y,
       focused: effectiveFocusNode != null,
       focusable: true,
       child: Container(
@@ -258,7 +254,7 @@ class _OudsPasswordInputState extends State<OudsPasswordInput> {
                 border: inputTextBorderModifier.getBorder(state, isError, widget.decoration.outlined),
 
                 // Border radius if enabled in theme configuration
-                borderRadius: inputTextBorderModifier.getBorderRadius(context, isBorderRadius),
+                borderRadius: inputTextBorderModifier.getBorderRadius(context),
               ),
               child: ConstrainedBox(
                 // Minimum height constraint for the input container
@@ -359,8 +355,8 @@ class _OudsPasswordInputState extends State<OudsPasswordInput> {
   /// - Shows hint text if provided, styled according to theme.
   /// - Adds prefix and suffix widgets when specified, with proper styling and spacing.
   /// - Uses dense layout for compact appearance.
-  TextField _buildTextField(
-      OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme, BuildContext context, OudsTextInputTokens textInput, bool effectiveIsFocused) {
+  TextField _buildTextField(OudsFormFieldsTextColorModifier inputTextTextModifier, OudsFormFieldsControlState state, bool isError, FocusNode? effectiveFocusNode, OudsThemeContract theme,
+      BuildContext context, OudsTextInputTokens textInput, bool effectiveIsFocused) {
     return TextField(
       cursorColor: inputTextTextModifier.getCursorTextColor(state, isError),
       focusNode: effectiveFocusNode,

--- a/ouds_core/lib/components/pin_code_input/digit_input/ouds_digit_input.dart
+++ b/ouds_core/lib/components/pin_code_input/digit_input/ouds_digit_input.dart
@@ -32,9 +32,6 @@ import 'package:ouds_theme_contract/ouds_theme.dart';
 ///
 /// - [hintText]: A short placeholder or hint shown inside the input when empty.
 ///
-/// - [roundedCorner]: Defines the visual border shape of the Pin Code.
-///   `false` for a square finish , `true` For a finish with rounded corner.
-///
 /// - [hiddenPassword]: Controls whether the characters entered in the pin code input should be displayed as plain text or hidden.
 ///
 /// - [isOutlined]: A boolean value that defines the visual style of the Pin Code Input.
@@ -46,14 +43,12 @@ import 'package:ouds_theme_contract/ouds_theme.dart';
 ///
 class OudsDigitInputDecoration {
   final String? hintText; //placeholder
-  final bool roundedCorner;
   final bool hiddenPassword;
   final bool isOutlined;
   final bool constrainedMaxWidth;
 
   const OudsDigitInputDecoration({
     this.hintText,
-    this.roundedCorner = false,
     this.hiddenPassword = true,
     this.isOutlined = false,
     this.constrainedMaxWidth = false,
@@ -177,7 +172,7 @@ class _OudsDigitInputState extends State<OudsDigitInput> {
           decoration: BoxDecoration(
             color: pinCodeInputBackgroundModifier.getPinCodeBackgroundColor(state, widget.isError, widget.digitInputDecoration!.isOutlined),
             border: pinCodeInputBorderModifier.getPinCodeBorder(state, widget.isError, widget.digitInputDecoration!.isOutlined),
-            borderRadius: textInputBorderModifier.getBorderRadius(context, widget.digitInputDecoration?.roundedCorner),
+            borderRadius: textInputBorderModifier.getBorderRadius(context),
           ),
           child: KeyboardListener(
             focusNode: _keyboardFocusNode,

--- a/ouds_core/lib/components/pin_code_input/internal/modifier/ouds_pin_code_input_border_modifier.dart
+++ b/ouds_core/lib/components/pin_code_input/internal/modifier/ouds_pin_code_input_border_modifier.dart
@@ -15,8 +15,8 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_core/components/pin_code_input/internal/ouds_pin_code_input_control_state.dart';
+import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// A class that provides the border color for the OudsPinCodeInput based on its state and selection
 class OudsPinCodeInputBorderModifier {
@@ -26,29 +26,29 @@ class OudsPinCodeInputBorderModifier {
 
   /// Gets the borderSide based on the pin code input state and whether it is selected
   Border getPinCodeBorder(OudsPinCodeInputControlState state, [bool isError = false, bool? isOutlined]) {
-      switch (state) {
-        case OudsPinCodeInputControlState.enabled:
-          return Border(
-            bottom: getPinCodeBorderSideByState(state,isError),
-            top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-          );
-        case OudsPinCodeInputControlState.hovered:
-          return Border(
-            bottom: getPinCodeBorderSideByState(state,isError),
-            top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-          );
-        case OudsPinCodeInputControlState.focused:
-          return Border(
-            bottom: getPinCodeBorderSideByState(state,isError),
-            top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-            right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state,isError),
-          );
-      }
+    switch (state) {
+      case OudsPinCodeInputControlState.enabled:
+        return Border(
+          bottom: getPinCodeBorderSideByState(state, isError),
+          top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+        );
+      case OudsPinCodeInputControlState.hovered:
+        return Border(
+          bottom: getPinCodeBorderSideByState(state, isError),
+          top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+        );
+      case OudsPinCodeInputControlState.focused:
+        return Border(
+          bottom: getPinCodeBorderSideByState(state, isError),
+          top: !isOutlined! ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          left: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+          right: !isOutlined ? BorderSide.none : getPinCodeBorderSideByState(state, isError),
+        );
+    }
   }
 
   /// Returns a [BorderSide] based on the given [OudsPinCodeInputControlState].
@@ -60,13 +60,16 @@ class OudsPinCodeInputBorderModifier {
 
     switch (state) {
       case OudsPinCodeInputControlState.enabled:
-        return isError? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
+        return isError
+            ? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
             : BorderSide(color: textInputToken.colorBorderEnabled, width: textInputToken.borderWidthDefault);
       case OudsPinCodeInputControlState.hovered:
-        return isError? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
+        return isError
+            ? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
             : BorderSide(color: textInputToken.colorBorderHover, width: textInputToken.borderWidthDefault);
       case OudsPinCodeInputControlState.focused:
-        return isError? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
+        return isError
+            ? BorderSide(color: colorToken.actionNegativeEnabled, width: textInputToken.borderWidthDefault)
             : BorderSide(color: textInputToken.colorBorderFocus, width: textInputToken.borderWidthFocus);
     }
   }

--- a/ouds_core/lib/components/pin_code_input/ouds_pin_code_input.dart
+++ b/ouds_core/lib/components/pin_code_input/ouds_pin_code_input.dart
@@ -208,7 +208,6 @@ class _OudsPinCodeInputState extends State<OudsPinCodeInput> {
                       length: widget.length,
                       digitInputDecoration: OudsDigitInputDecoration(
                         hintText: _hintText(index),
-                        roundedCorner: widget.digitInputDecoration.roundedCorner,
                         hiddenPassword: widget.digitInputDecoration.hiddenPassword,
                         isOutlined: widget.digitInputDecoration.isOutlined,
                       ),

--- a/ouds_core/lib/components/tag/ouds_input_tag.dart
+++ b/ouds_core/lib/components/tag/ouds_input_tag.dart
@@ -114,8 +114,8 @@ class _OudsInputTagState extends State<OudsInputTag> {
     return Visibility(visible: isVisible, child: _buildInputTag(context, tagBorderModifier, tagTextColorModifier, tagBackgroundColorModifier, tagState, isDisabled));
   }
 
-  Widget _buildInputTag(
-      BuildContext context, OudsInputTagControlBorderModifier tagBorderModifier, OudsTagStyleModifier tagTextColorModifier, OudsInputTagControlBackgroundColorModifier tagBgColorModifier, OudsTagControlState tagState, bool isDisabled) {
+  Widget _buildInputTag(BuildContext context, OudsInputTagControlBorderModifier tagBorderModifier, OudsTagStyleModifier tagTextColorModifier,
+      OudsInputTagControlBackgroundColorModifier tagBgColorModifier, OudsTagControlState tagState, bool isDisabled) {
     final tagToken = OudsTheme.of(context).componentsTokens(context).tag;
     final inputTagToken = OudsTheme.of(context).componentsTokens(context).inputTag;
     final borderTokens = OudsTheme.of(context).borderTokens;
@@ -136,7 +136,7 @@ class _OudsInputTagState extends State<OudsInputTag> {
             onTap: () {
               if (widget.onPressed != null) {
                 widget.onPressed!.call();
-                SemanticsService.announce(l10n!.core_tag_tag_input_removed_a11y(widget.label), TextDirection.ltr);
+                SemanticsService.announce(l10n?.core_tag_tag_input_removed_a11y(widget.label) ?? '', TextDirection.ltr);
               }
             },
             focusNode: _focusNode,
@@ -212,8 +212,8 @@ class _OudsInputTagState extends State<OudsInputTag> {
     );
   }
 
-  Widget _buildLayout(
-      BuildContext context, OudsInputTagControlBorderModifier tagBorderModifier, OudsTagStyleModifier tagTextColorModifier, OudsInputTagControlBackgroundColorModifier tagBgColorModifier, OudsTagControlState tagState, bool isDisabled) {
+  Widget _buildLayout(BuildContext context, OudsInputTagControlBorderModifier tagBorderModifier, OudsTagStyleModifier tagTextColorModifier,
+      OudsInputTagControlBackgroundColorModifier tagBgColorModifier, OudsTagControlState tagState, bool isDisabled) {
     final tagToken = OudsTheme.of(context).componentsTokens(context).tag;
     final typographyTokens = OudsTheme.of(context).typographyTokens;
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

- [x] #587 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/DEVELOP.md)
- [x] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [x] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] changelog.md has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
