### PR TITLE
fix: Ensure suggestion chips trigger actions on click

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] update tokens 1.9.0 - Component Alert ([#672](https://github.com/Orange-OpenSource/ouds-flutter/issues/672))
 
 ### Fixed
+- [Library] Nothing happens when clicking on the `suggestion chip` ([#723](https://github.com/Orange-OpenSource/ouds-flutter/issues/723))
 
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.1.2...1.2.0) - 2026-04-21
 ### Added

--- a/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
@@ -36,7 +36,7 @@ import 'package:provider/provider.dart';
 
 class ChipSuggestionDemoScreen extends StatefulWidget {
   final String? previousPageTitle;
-  const ChipSuggestionDemoScreen({super.key,this.previousPageTitle});
+  const ChipSuggestionDemoScreen({super.key, this.previousPageTitle});
 
   @override
   State<StatefulWidget> createState() => _ChipSuggestionDemoScreenState();
@@ -58,7 +58,11 @@ class _ChipSuggestionDemoScreenState extends State<ChipSuggestionDemoScreen> {
       child: ChipCustomization(
         key: _scaffoldKey,
         child: Padding(
-          padding: EdgeInsets.only(bottom: defaultTargetPlatform == TargetPlatform.android ? MediaQuery.of(context).viewPadding.bottom : OudsTheme.of(context).spaceScheme(context).paddingBlockNone),
+          padding: EdgeInsets.only(
+            bottom: defaultTargetPlatform == TargetPlatform.android
+                ? MediaQuery.of(context).viewPadding.bottom
+                : OudsTheme.of(context).spaceScheme(context).paddingBlockNone,
+          ),
           child: Scaffold(
             bottomSheet: OudsSheetsBottom(
               onExpansionChanged: _onExpansionChanged,
@@ -69,7 +73,8 @@ class _ChipSuggestionDemoScreenState extends State<ChipSuggestionDemoScreen> {
             appBar: MainAppBar(
               title: context.l10n.app_components_suggestionChip_label,
               showBackButton: true,
-            previousPageTitle: widget.previousPageTitle),
+              previousPageTitle: widget.previousPageTitle,
+            ),
             body: ExcludeSemantics(
               excluding: !_isBottomSheetExpanded,
               child: _Body(),
@@ -92,19 +97,23 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    ThemeController? themeController = Provider.of<ThemeController>(context, listen: false);
+    ThemeController? themeController = Provider.of<ThemeController>(
+      context,
+      listen: false,
+    );
     return DetailScreenDescription(
-      description: context.l10n.app_components_chip_suggestionChip_description_text,
+      description:
+          context.l10n.app_components_chip_suggestionChip_description_text,
       widget: Column(
         children: [
           _ChipSuggestionDemo(),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
-          Code(
-            code: ChipSuggestionCodeGenerator.updateCode(context),
+          SizedBox(
+            height: themeController.currentTheme
+                .spaceScheme(context)
+                .fixedMedium,
           ),
-          ReferenceDesignVersionComponent(
-            version: OudsComponentVersion.chip,
-          )
+          Code(code: ChipSuggestionCodeGenerator.updateCode(context)),
+          ReferenceDesignVersionComponent(version: OudsComponentVersion.chip),
         ],
       ),
     );
@@ -134,7 +143,10 @@ class _ChipSuggestionDemoState extends State<_ChipSuggestionDemo> {
     return LightDarkBox(
       child: OudsSuggestionChip(
         label: ChipCustomizationUtils.getText(customizationState),
-        avatar: ChipCustomizationUtils.getIcon(customizationState, themeController!),
+        avatar: ChipCustomizationUtils.getIcon(
+          customizationState,
+          themeController!,
+        ),
         onPressed: customizationState?.hasEnabled == true ? () {} : null,
       ),
     );
@@ -167,7 +179,9 @@ class _CustomizationContentState extends State<_CustomizationContent> {
 
   @override
   Widget build(BuildContext context) {
-    final ChipCustomizationState? customizationState = ChipCustomization.of(context);
+    final ChipCustomizationState? customizationState = ChipCustomization.of(
+      context,
+    );
 
     return CustomizableSection(
       children: [
@@ -194,7 +208,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           text: customizationState.labelText,
           focusNode: labelFocus,
           fieldType: FieldType.label,
-        )
+        ),
       ],
     );
   }

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] update tokens 1.9.0 - Component Alert ([#672](https://github.com/Orange-OpenSource/ouds-flutter/issues/672))
 
 ### Fixed
+- [Library] Nothing happens when clicking on the `suggestion chip` ([#723](https://github.com/Orange-OpenSource/ouds-flutter/issues/723))
 
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.1.2...1.2.0) - 2026-04-21
 ### Added

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -14,30 +14,23 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:ouds_core/components/chip/internal/ouds_chip_background_modifier.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_border_modifier.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_control_state.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_icon_style_modifier.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_text_style_modifier.dart';
 import 'package:ouds_core/components/common/OudsBorder.dart';
 import 'package:ouds_core/components/control/internal/interaction/ouds_inherited_interaction_model.dart';
-import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
-import 'package:ouds_core/components/chip/internal/ouds_chip_background_modifier.dart';
+import 'package:ouds_theme_contract/ouds_theme.dart';
 
 ///The [OudsChipLayout] defines the layout of the chip’s content.
 ///
 /// This enum controls whether the chip displays text, an icon, or both.
-enum OudsChipLayout {
-  textOnly,
-  iconAndText,
-  iconOnly;
-}
+enum OudsChipLayout { textOnly, iconAndText, iconOnly }
 
 /// The [OudsChipStyle] defines the chip's visual behavior and feedback.
-enum OudsChipStyle {
-  defaultStyle,
-  selected,
-}
+enum OudsChipStyle { defaultStyle, selected }
 
 ///
 /// [OUDS Chip design guidelines](https://r.orange.fr/r/S-ouds-doc-suggestion-chip)
@@ -142,29 +135,58 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
   }
 
   void _handleFocusChange(bool focus) {
-    if (widget.onPressed == null) _isFocused = false; // Ignore focus changes if disabled
+    if (widget.onPressed == null)
+      _isFocused = false; // Ignore focus changes if disabled
     setState(() => _isFocused = focus);
   }
 
   @override
   Widget build(BuildContext context) {
     final isDisabled = widget.onPressed == null;
-    final interactionModelHover = OudsInheritedInteractionModel.of(context, InteractionAspect.hover);
-    final interactionModelPressed = OudsInheritedInteractionModel.of(context, InteractionAspect.pressed);
+    final interactionModelHover = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.hover,
+    );
+    final interactionModelPressed = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.pressed,
+    );
     final isHovered = interactionModelHover?.state.isHovered ?? false;
     final isPressed = interactionModelPressed?.state.isPressed ?? false;
-    final chipStateDeterminer = OudsChipControlStateDeterminer(enabled: !isDisabled, isPressed: isPressed || _isPressed, isHovered: isHovered || _isHovered, isFocused: _isFocused);
+    final chipStateDeterminer = OudsChipControlStateDeterminer(
+      enabled: !isDisabled,
+      isPressed: isPressed || _isPressed,
+      isHovered: isHovered || _isHovered,
+      isFocused: _isFocused,
+    );
     final chipState = chipStateDeterminer.determineControlState();
     final chipBorderModifier = OudsChipControlBorderModifier(context);
     final chipTextColorModifier = OudsChipControlTextColorModifier(context);
     final chipIconColorModifier = OudsChipControlIconColorModifier(context);
-    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(context);
+    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(
+      context,
+    );
 
-    return _buildSuggestionChip(context, chipBorderModifier, chipTextColorModifier, chipBackgroundColorModifier, chipIconColorModifier, chipState, isDisabled);
+    return _buildSuggestionChip(
+      context,
+      chipBorderModifier,
+      chipTextColorModifier,
+      chipBackgroundColorModifier,
+      chipIconColorModifier,
+      chipState,
+      isDisabled,
+    );
   }
 
-  Widget _buildSuggestionChip(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier,
-      OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildSuggestionChip(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final borderTokens = OudsTheme.of(context).borderTokens;
     return Semantics(
@@ -176,7 +198,7 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
             minHeight: chipToken.sizeMinHeightInteractiveArea,
           ),
           child: InkWell(
-            onTap: () {},
+            onTap: widget.onPressed,
             focusNode: _focusNode,
             canRequestFocus: !isDisabled,
             splashColor: Colors.transparent,
@@ -215,11 +237,16 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                     child: Container(
                       decoration: BoxDecoration(
                         border: OudsBorder().borderAll(
-                          color: OudsTheme.of(context).colorScheme(context).borderFocus,
+                          color: OudsTheme.of(
+                            context,
+                          ).colorScheme(context).borderFocus,
                           width: OudsTheme.of(context).borderTokens.widthFocus,
                         ),
                         borderRadius: BorderRadius.circular(
-                          OudsTheme.of(context).componentsTokens(context).chip.borderRadius + OudsTheme.of(context).borderTokens.widthFocus,
+                          OudsTheme.of(
+                                context,
+                              ).componentsTokens(context).chip.borderRadius +
+                              OudsTheme.of(context).borderTokens.widthFocus,
                         ),
                       ),
                     ),
@@ -228,11 +255,17 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                 Container(
                   decoration: BoxDecoration(
                     border: OudsBorder().borderAll(
-                      color: _isFocused ? OudsTheme.of(context).colorScheme(context).borderFocusInset : Colors.transparent,
+                      color: _isFocused
+                          ? OudsTheme.of(
+                              context,
+                            ).colorScheme(context).borderFocusInset
+                          : Colors.transparent,
                       width: borderTokens.widthFocusInset,
                     ),
                     borderRadius: BorderRadius.circular(
-                      OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                      OudsTheme.of(
+                        context,
+                      ).componentsTokens(context).chip.borderRadius,
                     ),
                   ),
                   child: _buildLayout(
@@ -253,29 +286,66 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
     );
   }
 
-  Widget _buildLayout(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier,
-      OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlState chipState, bool isDisabled) {
-    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(context);
+  Widget _buildLayout(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
+    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(
+      context,
+    );
 
     switch (widget.layout) {
-      case  OudsChipLayout.iconOnly:
-        return _buildChipIconOnly(context, chipBorderModifier, chipIconColorModifier, chipBgColorModifier, chipState, isDisabled);
+      case OudsChipLayout.iconOnly:
+        return _buildChipIconOnly(
+          context,
+          chipBorderModifier,
+          chipIconColorModifier,
+          chipBgColorModifier,
+          chipState,
+          isDisabled,
+        );
       case OudsChipLayout.iconAndText:
-        return _buildChipIconAndText(context, chipBorderModifier, chipTextColorModifier, chipIconColorModifier, chipBgColorModifier, chipState, isDisabled);
+        return _buildChipIconAndText(
+          context,
+          chipBorderModifier,
+          chipTextColorModifier,
+          chipIconColorModifier,
+          chipBgColorModifier,
+          chipState,
+          isDisabled,
+        );
       case OudsChipLayout.textOnly:
-        return _buildChipTextOnly(context, chipBorderModifier, chipTextColorModifier, chipBackgroundColorModifier, chipState, isDisabled);
+        return _buildChipTextOnly(
+          context,
+          chipBorderModifier,
+          chipTextColorModifier,
+          chipBackgroundColorModifier,
+          chipState,
+          isDisabled,
+        );
     }
   }
 
   Widget _buildChipIconOnly(
-      BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final l10n = OudsLocalizations.of(context);
 
     return Semantics(
       label: l10n?.core_chip_chip_icon_a11y,
       button: true,
-      enabled:  widget.onPressed != null,
+      enabled: widget.onPressed != null,
       child: Stack(
         children: [
           // Draws the border behind the content without affecting layout size.
@@ -287,7 +357,9 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
               decoration: BoxDecoration(
                 border: chipBorderModifier.getBorder(chipState),
                 borderRadius: BorderRadius.circular(
-                  OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                  OudsTheme.of(
+                    context,
+                  ).componentsTokens(context).chip.borderRadius,
                 ),
               ),
             ),
@@ -309,13 +381,13 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                 ExcludeSemantics(
-                   child:  OudsSuggestionChip.buildIcon(
-                     context,
-                     widget.avatar!,
-                     chipState,
-                   ),
-                 ),
+                  ExcludeSemantics(
+                    child: OudsSuggestionChip.buildIcon(
+                      context,
+                      widget.avatar!,
+                      chipState,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -325,8 +397,15 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
     );
   }
 
-  Widget _buildChipIconAndText(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlIconColorModifier chipIconColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildChipIconAndText(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final l10n = OudsLocalizations.of(context);
 
@@ -345,7 +424,9 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
               decoration: BoxDecoration(
                 border: chipBorderModifier.getBorder(chipState),
                 borderRadius: BorderRadius.circular(
-                  OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                  OudsTheme.of(
+                    context,
+                  ).componentsTokens(context).chip.borderRadius,
                 ),
               ),
             ),
@@ -369,7 +450,11 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   ExcludeSemantics(
-                    child: OudsSuggestionChip.buildIcon(context, widget.avatar!, chipState),
+                    child: OudsSuggestionChip.buildIcon(
+                      context,
+                      widget.avatar!,
+                      chipState,
+                    ),
                   ),
                   SizedBox(width: chipToken.spaceColumnGapIcon),
                   Flexible(
@@ -377,8 +462,12 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                       child: Text(
                         widget.label ?? "",
                         textAlign: TextAlign.center,
-                        style: OudsTheme.of(context).typographyTokens.typeLabelStrongMedium(context).copyWith(
-                              color: chipTextColorModifier.getTextColor(chipState),
+                        style: OudsTheme.of(context).typographyTokens
+                            .typeLabelStrongMedium(context)
+                            .copyWith(
+                              color: chipTextColorModifier.getTextColor(
+                                chipState,
+                              ),
                             ),
                       ),
                     ),
@@ -393,15 +482,21 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
   }
 
   Widget _buildChipTextOnly(
-      BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final l10n = OudsLocalizations.of(context);
 
     return Semantics(
-        label: l10n?.core_chip_chip_label_a11y,
-        button: true,
-        enabled: widget.onPressed != null,
-        child: Stack(
+      label: l10n?.core_chip_chip_label_a11y,
+      button: true,
+      enabled: widget.onPressed != null,
+      child: Stack(
         children: [
           // Draws the border behind the content without affecting layout size.
           // This allows the border (e.g. thickness or color) to change dynamically
@@ -412,7 +507,9 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
               decoration: BoxDecoration(
                 border: chipBorderModifier.getBorder(chipState),
                 borderRadius: BorderRadius.circular(
-                  OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                  OudsTheme.of(
+                    context,
+                  ).componentsTokens(context).chip.borderRadius,
                 ),
               ),
             ),
@@ -438,8 +535,12 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                       child: Text(
                         widget.label ?? "",
                         textAlign: TextAlign.center,
-                        style: OudsTheme.of(context).typographyTokens.typeLabelStrongMedium(context).copyWith(
-                              color: chipTextColorModifier.getTextColor(chipState),
+                        style: OudsTheme.of(context).typographyTokens
+                            .typeLabelStrongMedium(context)
+                            .copyWith(
+                              color: chipTextColorModifier.getTextColor(
+                                chipState,
+                              ),
                             ),
                       ),
                     ),


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

- #723 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/DEVELOP.md)
- [ ] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test (dark mode, RTL, landscape display, tablet)
- [ ] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [ ] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] CHANGELOG.md files have been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
