### PR TITLE
chore: resolve null check of a11y highcontrast

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- [Library] Null check operator used on a null value in all components has isHighContrastEnabled ([#756](https://github.com/Orange-OpenSource/ouds-flutter/issues/756))
 
 ## [1.3.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.2.0...1.3.0) - 2026-05-08
 ### Added

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- [Library] Null check operator used on a null value in all components has isHighContrastEnabled ([#756](https://github.com/Orange-OpenSource/ouds-flutter/issues/756))
 
 ## [1.3.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/1.2.0...1.3.0) - 2026-05-08
 ### Added

--- a/ouds_core/lib/components/checkbox/ouds_checkbox.dart
+++ b/ouds_core/lib/components/checkbox/ouds_checkbox.dart
@@ -97,18 +97,27 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = value;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final interactionModelHover = OudsInheritedInteractionModel.of(context, InteractionAspect.hover);
-    final interactionModelPressed = OudsInheritedInteractionModel.of(context, InteractionAspect.pressed);
+    final interactionModelHover = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.hover,
+    );
+    final interactionModelPressed = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.pressed,
+    );
     final isHoveredInherited = interactionModelHover?.state.isHovered ?? false;
-    final isPressedInherited = interactionModelPressed?.state.isPressed ?? false;
+    final isPressedInherited =
+        interactionModelPressed?.state.isPressed ?? false;
     final bool isReadOnly = widget.readOnly;
 
     final checkboxStateDeterminer = OudsControlStateDeterminer(
@@ -123,21 +132,27 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
     final checkboxBackgroundModifier = OudsControlBackgroundModifier(context);
     final checkboxTickModifier = OudsControlTickModifier(context);
     final checkbox = OudsTheme.of(context).componentsTokens(context).checkbox;
-    final controlItem = OudsTheme.of(context).componentsTokens(context).controlItem;
+    final controlItem = OudsTheme.of(
+      context,
+    ).componentsTokens(context).controlItem;
     final l10n = OudsLocalizations.of(context);
 
     String? semanticValue = widget.value == true
         ? l10n?.core_checkbox_checked_a11y
         : widget.value == null
-            ? l10n?.core_checkbox_indeterminate_a11y
-            : l10n?.core_checkbox_unchecked_a11y;
+        ? l10n?.core_checkbox_indeterminate_a11y
+        : l10n?.core_checkbox_unchecked_a11y;
 
-    String toggleActionLabel = (widget.onChanged != null && !widget.readOnly) ? '${l10n?.core_checkbox_hint_a11y}' : '';
+    String toggleActionLabel = (widget.onChanged != null && !widget.readOnly)
+        ? '${l10n?.core_checkbox_hint_a11y}'
+        : '';
 
     return Semantics(
       enabled: widget.onChanged != null && !(widget.readOnly),
       value: '${l10n?.core_checkbox_trait_a11y}. $semanticValue',
-      hint: widget.isError ? '${'${l10n!.core_common_error_a11y}, '}$toggleActionLabel' : toggleActionLabel,
+      hint: widget.isError
+          ? '${'${l10n!.core_common_error_a11y}, '}$toggleActionLabel'
+          : toggleActionLabel,
       // onTap allows TalkBack to say "double tap to activate," so we need to do an exclude semantics here.
       excludeSemantics: true,
       child: Material(
@@ -186,9 +201,15 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                 minWidth: checkbox.sizeMinWidth,
               ),
               decoration: BoxDecoration(
-                color: _isPressed ? checkboxBackgroundModifier.getBackgroundColor(checkboxState) : Colors.transparent,
+                color: _isPressed
+                    ? checkboxBackgroundModifier.getBackgroundColor(
+                        checkboxState,
+                      )
+                    : Colors.transparent,
                 borderRadius: BorderRadius.circular(
-                  checkboxBorderModifier.getBorderRadius(controlItem.borderRadiusItemOnly),
+                  checkboxBorderModifier.getBorderRadius(
+                    controlItem.borderRadiusItemOnly,
+                  ),
                 ),
               ),
               child: Center(
@@ -198,7 +219,9 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                     height: checkbox.sizeIndicator,
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(
-                        checkboxBorderModifier.getBorderRadius(checkbox.borderRadius),
+                        checkboxBorderModifier.getBorderRadius(
+                          checkbox.borderRadius,
+                        ),
                       ),
                       child: Stack(
                         fit: StackFit.expand,
@@ -206,7 +229,12 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                           DecoratedBox(
                             decoration: BoxDecoration(
                               border: OudsBorder().borderAll(
-                                color: checkboxBorderModifier.getBorderColor(checkboxState, widget.isError, isCheckedOrIndeterminate(widget.value), _isHighContrast),
+                                color: checkboxBorderModifier.getBorderColor(
+                                  checkboxState,
+                                  widget.isError,
+                                  isCheckedOrIndeterminate(widget.value),
+                                  _isHighContrast,
+                                ),
                                 width: checkboxBorderModifier.getBorderWidth(
                                   checkboxState,
                                   isCheckedOrIndeterminate(widget.value),
@@ -214,7 +242,9 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                                 ),
                               ),
                               borderRadius: BorderRadius.circular(
-                                checkboxBorderModifier.getBorderRadius(checkbox.borderRadius),
+                                checkboxBorderModifier.getBorderRadius(
+                                  checkbox.borderRadius,
+                                ),
                               ),
                             ),
                           ),
@@ -226,7 +256,11 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                                 package: OudsTheme.of(context).packageName,
                                 fit: BoxFit.contain,
                                 colorFilter: ColorFilter.mode(
-                                  checkboxTickModifier.getTickColor(checkboxState, widget.isError, _isHighContrast),
+                                  checkboxTickModifier.getTickColor(
+                                    checkboxState,
+                                    widget.isError,
+                                    _isHighContrast,
+                                  ),
                                   BlendMode.srcIn,
                                 ),
                               ),
@@ -239,7 +273,11 @@ class _OudsCheckboxState extends State<OudsCheckbox> {
                                 package: OudsTheme.of(context).packageName,
                                 fit: BoxFit.contain,
                                 colorFilter: ColorFilter.mode(
-                                  checkboxTickModifier.getTickColor(checkboxState, widget.isError, _isHighContrast),
+                                  checkboxTickModifier.getTickColor(
+                                    checkboxState,
+                                    widget.isError,
+                                    _isHighContrast,
+                                  ),
                                   BlendMode.srcIn,
                                 ),
                               ),

--- a/ouds_core/lib/components/chip/ouds_filter_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_filter_chip.dart
@@ -30,17 +30,10 @@ import 'package:ouds_theme_contract/ouds_theme.dart';
 ///The [OudsChipLayout] defines the layout of the chip’s content.
 ///
 /// This enum controls whether the chip displays text, an icon, or both.
-enum OudsChipLayout {
-  textOnly,
-  iconAndText,
-  iconOnly;
-}
+enum OudsChipLayout { textOnly, iconAndText, iconOnly }
 
 /// The [OudsChipStyle] defines the chip's visual behavior and feedback.
-enum OudsChipStyle {
-  defaultStyle,
-  selected,
-}
+enum OudsChipStyle { defaultStyle, selected }
 
 ///
 /// [OUDS Chip design guidelines](https://r.orange.fr/r/S-ouds-doc-filter-chip)
@@ -79,7 +72,13 @@ class OudsFilterChip extends StatefulWidget {
   final bool? selected;
   final ValueChanged<bool>? onSelected;
 
-  const OudsFilterChip({super.key, this.label, this.avatar, this.selected, this.onSelected});
+  const OudsFilterChip({
+    super.key,
+    this.label,
+    this.avatar,
+    this.selected,
+    this.onSelected,
+  });
 
   static Widget buildIcon(
     BuildContext context,
@@ -88,14 +87,19 @@ class OudsFilterChip extends StatefulWidget {
     bool selected,
   ) {
     final controlIconModifier = OudsChipControlIconColorModifier(context);
-    final sizeIcon = OudsTheme.of(context).componentsTokens(context).chip.sizeIcon;
+    final sizeIcon = OudsTheme.of(
+      context,
+    ).componentsTokens(context).chip.sizeIcon;
     return SvgPicture.asset(
       assetName,
       fit: BoxFit.contain,
       width: sizeIcon,
       height: sizeIcon,
       colorFilter: ColorFilter.mode(
-        controlIconModifier.getIconColor(controlItemState, selected), //selected always true when buildIcon
+        controlIconModifier.getIconColor(
+          controlItemState,
+          selected,
+        ), //selected always true when buildIcon
         BlendMode.srcIn,
       ),
     );
@@ -142,9 +146,11 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = value;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 
@@ -155,38 +161,72 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
   }
 
   void _handleFocusChange(bool focus) {
-    if (widget.onSelected == null) _isFocused = false; // Ignore focus changes if disabled
+    if (widget.onSelected == null)
+      _isFocused = false; // Ignore focus changes if disabled
     setState(() => _isFocused = focus);
   }
 
   @override
   Widget build(BuildContext context) {
     final isDisabled = widget.onSelected == null;
-    final interactionModelHover = OudsInheritedInteractionModel.of(context, InteractionAspect.hover);
-    final interactionModelPressed = OudsInheritedInteractionModel.of(context, InteractionAspect.pressed);
+    final interactionModelHover = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.hover,
+    );
+    final interactionModelPressed = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.pressed,
+    );
     final isHovered = interactionModelHover?.state.isHovered ?? false;
     final isPressed = interactionModelPressed?.state.isPressed ?? false;
 
-    final chipStateDeterminer = OudsChipControlStateDeterminer(enabled: !isDisabled, isPressed: _isPressed || isPressed, isHovered: isHovered || _isHovered, isFocused: _isFocused);
+    final chipStateDeterminer = OudsChipControlStateDeterminer(
+      enabled: !isDisabled,
+      isPressed: _isPressed || isPressed,
+      isHovered: isHovered || _isHovered,
+      isFocused: _isFocused,
+    );
 
     final chipState = chipStateDeterminer.determineControlState();
     final chipBorderModifier = OudsChipControlBorderModifier(context);
     final chipTextColorModifier = OudsChipControlTextColorModifier(context);
     final chipIconColorModifier = OudsChipControlIconColorModifier(context);
-    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(context);
+    final chipBackgroundColorModifier = OudsChipControlBackgroundColorModifier(
+      context,
+    );
 
-    return _buildFilterChip(context, chipBorderModifier, chipTextColorModifier, chipBackgroundColorModifier, chipIconColorModifier, chipState, isDisabled);
+    return _buildFilterChip(
+      context,
+      chipBorderModifier,
+      chipTextColorModifier,
+      chipBackgroundColorModifier,
+      chipIconColorModifier,
+      chipState,
+      isDisabled,
+    );
   }
 
-  Widget _buildFilterChip(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildFilterChip(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final borderTokens = OudsTheme.of(context).borderTokens;
     final l10n = OudsLocalizations.of(context);
     final enabled = widget.onSelected != null;
-    String semanticsLabel = '${widget.selected == true ? l10n?.core_common_selected_a11y : l10n?.core_common_unselected_a11y},'
+    String semanticsLabel =
+        '${widget.selected == true ? l10n?.core_common_selected_a11y : l10n?.core_common_unselected_a11y},'
         ' ${widget.label ?? ""}, '
-        '${enabled && widget.selected == true ? l10n?.core_filterChip_hint_unselected_a11y : enabled && widget.selected == false ? l10n?.core_filterChip_hint_selected_a11y : ''}';
+        '${enabled && widget.selected == true
+            ? l10n?.core_filterChip_hint_unselected_a11y
+            : enabled && widget.selected == false
+            ? l10n?.core_filterChip_hint_selected_a11y
+            : ''}';
 
     return Semantics(
       button: true,
@@ -238,11 +278,16 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                       child: Container(
                         decoration: BoxDecoration(
                           border: OudsBorder().borderAll(
-                            color: OudsTheme.of(context).colorScheme(context).borderFocus,
+                            color: OudsTheme.of(
+                              context,
+                            ).colorScheme(context).borderFocus,
                             width: borderTokens.widthFocus,
                           ),
                           borderRadius: BorderRadius.circular(
-                            OudsTheme.of(context).componentsTokens(context).chip.borderRadius + OudsTheme.of(context).borderTokens.widthFocus,
+                            OudsTheme.of(
+                                  context,
+                                ).componentsTokens(context).chip.borderRadius +
+                                OudsTheme.of(context).borderTokens.widthFocus,
                           ),
                         ),
                       ),
@@ -252,11 +297,17 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                   Container(
                     decoration: BoxDecoration(
                       border: OudsBorder().borderAll(
-                        color: _isFocused ? OudsTheme.of(context).colorScheme(context).borderFocusInset : Colors.transparent,
+                        color: _isFocused
+                            ? OudsTheme.of(
+                                context,
+                              ).colorScheme(context).borderFocusInset
+                            : Colors.transparent,
                         width: borderTokens.widthFocusInset,
                       ),
                       borderRadius: BorderRadius.circular(
-                        OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                        OudsTheme.of(
+                          context,
+                        ).componentsTokens(context).chip.borderRadius,
                       ),
                     ),
                     child: _buildLayout(
@@ -278,8 +329,14 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildIconOnly(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildIconOnly(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
     final theme = OudsTheme.of(context);
 
@@ -292,9 +349,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
         Positioned.fill(
           child: Container(
             decoration: BoxDecoration(
-              border: chipBorderModifier.getBorder(chipState, _isHighContrast, widget.selected!),
+              border: chipBorderModifier.getBorder(
+                chipState,
+                _isHighContrast,
+                widget.selected!,
+              ),
               borderRadius: BorderRadius.circular(
-                OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                OudsTheme.of(
+                  context,
+                ).componentsTokens(context).chip.borderRadius,
               ),
             ),
           ),
@@ -307,7 +370,10 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
           ),
           child: Container(
             width: !widget.selected! ? chipToken.sizeMinWidth : null,
-            color: chipBgColorModifier.getBackgroundColor(chipState, widget.selected!),
+            color: chipBgColorModifier.getBackgroundColor(
+              chipState,
+              widget.selected!,
+            ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlockIconOnly,
               bottom: chipToken.spacePaddingBlockIconOnly,
@@ -318,7 +384,9 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: widget.selected! ? chipToken.spaceColumnGapIcon : theme.spaceScheme(context).fixedNone,
+              spacing: widget.selected!
+                  ? chipToken.spaceColumnGapIcon
+                  : theme.spaceScheme(context).fixedNone,
               children: [
                 Visibility(
                   visible: widget.selected!,
@@ -330,15 +398,23 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                       width: chipToken.sizeIcon,
                       height: chipToken.sizeIcon,
                       colorFilter: ColorFilter.mode(
-                        chipIconColorModifier.getTickColor(chipState,_isHighContrast),
+                        chipIconColorModifier.getTickColor(
+                          chipState,
+                          _isHighContrast,
+                        ),
                         BlendMode.srcIn,
                       ),
                     ),
                   ),
                 ),
                 ExcludeSemantics(
-                  child: OudsFilterChip.buildIcon(context, widget.avatar!, chipState, widget.selected!),
-                )
+                  child: OudsFilterChip.buildIcon(
+                    context,
+                    widget.avatar!,
+                    chipState,
+                    widget.selected!,
+                  ),
+                ),
               ],
             ),
           ),
@@ -347,8 +423,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildIconAndText(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
-      OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildIconAndText(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
 
     return Stack(
@@ -360,9 +443,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
         Positioned.fill(
           child: Container(
             decoration: BoxDecoration(
-              border: chipBorderModifier.getBorder(chipState, _isHighContrast, widget.selected!),
+              border: chipBorderModifier.getBorder(
+                chipState,
+                _isHighContrast,
+                widget.selected!,
+              ),
               borderRadius: BorderRadius.circular(
-                OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                OudsTheme.of(
+                  context,
+                ).componentsTokens(context).chip.borderRadius,
               ),
             ),
           ),
@@ -375,11 +464,16 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
           ),
           child: Container(
             //margin: EdgeInsets.all(1),
-            color: chipBgColorModifier.getBackgroundColor(chipState, widget.selected!),
+            color: chipBgColorModifier.getBackgroundColor(
+              chipState,
+              widget.selected!,
+            ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlock,
               bottom: chipToken.spacePaddingBlock,
-              start: widget.selected == true ? chipToken.spacePaddingInlineIcon : chipToken.spacePaddingInlineIconNone,
+              start: widget.selected == true
+                  ? chipToken.spacePaddingInlineIcon
+                  : chipToken.spacePaddingInlineIconNone,
               end: chipToken.spacePaddingInlineIcon,
             ),
             child: Row(
@@ -396,7 +490,10 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                       height: chipToken.sizeIcon,
                       fit: BoxFit.contain,
                       colorFilter: ColorFilter.mode(
-                        chipIconColorModifier.getTickColor(chipState,_isHighContrast),
+                        chipIconColorModifier.getTickColor(
+                          chipState,
+                          _isHighContrast,
+                        ),
                         BlendMode.srcIn,
                       ),
                     ),
@@ -408,17 +505,27 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                     child: Text(
                       widget.label ?? "",
                       textAlign: TextAlign.center,
-                        style: OudsTheme.of(context).typographyTokens.typeLabelModerateMedium(context)
-                            .copyWith(
-                          color: chipTextColorModifier.getTextColor(chipState,_isHighContrast, widget.selected!),
-                        )
+                      style: OudsTheme.of(context).typographyTokens
+                          .typeLabelModerateMedium(context)
+                          .copyWith(
+                            color: chipTextColorModifier.getTextColor(
+                              chipState,
+                              _isHighContrast,
+                              widget.selected!,
+                            ),
+                          ),
                     ),
                   ),
                 ),
                 SizedBox(width: chipToken.spaceColumnGapIcon),
                 ExcludeSemantics(
-                  child: OudsFilterChip.buildIcon(context, widget.avatar!, chipState, widget.selected!),
-                )
+                  child: OudsFilterChip.buildIcon(
+                    context,
+                    widget.avatar!,
+                    chipState,
+                    widget.selected!,
+                  ),
+                ),
               ],
             ),
           ),
@@ -427,8 +534,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildTextOnly(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlTextColorModifier chipTextColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlIconColorModifier chipIconColorModifier, OudsChipControlState chipState, bool isDisabled) {
+  Widget _buildTextOnly(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     final chipToken = OudsTheme.of(context).componentsTokens(context).chip;
 
     return Stack(
@@ -441,9 +555,15 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
           child: Container(
             //color: Colors.red,
             decoration: BoxDecoration(
-              border: chipBorderModifier.getBorder(chipState, _isHighContrast, widget.selected!),
+              border: chipBorderModifier.getBorder(
+                chipState,
+                _isHighContrast,
+                widget.selected!,
+              ),
               borderRadius: BorderRadius.circular(
-                OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
+                OudsTheme.of(
+                  context,
+                ).componentsTokens(context).chip.borderRadius,
               ),
             ),
           ),
@@ -455,11 +575,16 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
             OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
           ),
           child: Container(
-            color: chipBgColorModifier.getBackgroundColor(chipState, widget.selected!),
+            color: chipBgColorModifier.getBackgroundColor(
+              chipState,
+              widget.selected!,
+            ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlock,
               bottom: chipToken.spacePaddingBlock,
-              start: widget.selected == true ? chipToken.spacePaddingInlineIcon : chipToken.spacePaddingInlineIconNone,
+              start: widget.selected == true
+                  ? chipToken.spacePaddingInlineIcon
+                  : chipToken.spacePaddingInlineIconNone,
               end: chipToken.spacePaddingInlineIconNone,
             ),
             child: Row(
@@ -476,7 +601,10 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                       package: OudsTheme.of(context).packageName,
                       fit: BoxFit.contain,
                       colorFilter: ColorFilter.mode(
-                        chipIconColorModifier.getTickColor(chipState,_isHighContrast),
+                        chipIconColorModifier.getTickColor(
+                          chipState,
+                          _isHighContrast,
+                        ),
                         BlendMode.srcIn,
                       ),
                     ),
@@ -488,13 +616,18 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                     child: Text(
                       widget.label ?? "",
                       textAlign: TextAlign.center,
-                      style: OudsTheme.of(context).typographyTokens.typeLabelModerateMedium(context)
+                      style: OudsTheme.of(context).typographyTokens
+                          .typeLabelModerateMedium(context)
                           .copyWith(
-                        color: chipTextColorModifier.getTextColor(chipState,_isHighContrast, widget.selected!),
-                      )
-                      ),
+                            color: chipTextColorModifier.getTextColor(
+                              chipState,
+                              _isHighContrast,
+                              widget.selected!,
+                            ),
+                          ),
                     ),
                   ),
+                ),
               ],
             ),
           ),
@@ -503,16 +636,45 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     );
   }
 
-  Widget _buildLayout(BuildContext context, OudsChipControlBorderModifier chipBorderModifier, OudsChipControlIconColorModifier chipIconColorModifier,
-      OudsChipControlBackgroundColorModifier chipBgColorModifier, OudsChipControlTextColorModifier chipTextColorModifier, OudsChipControlState chipState, bool isDisabled) {
-
+  Widget _buildLayout(
+    BuildContext context,
+    OudsChipControlBorderModifier chipBorderModifier,
+    OudsChipControlIconColorModifier chipIconColorModifier,
+    OudsChipControlBackgroundColorModifier chipBgColorModifier,
+    OudsChipControlTextColorModifier chipTextColorModifier,
+    OudsChipControlState chipState,
+    bool isDisabled,
+  ) {
     switch (widget.layout) {
       case OudsChipLayout.iconOnly:
-        return _buildIconOnly(context, chipBorderModifier, chipIconColorModifier, chipBgColorModifier, chipState, isDisabled);
+        return _buildIconOnly(
+          context,
+          chipBorderModifier,
+          chipIconColorModifier,
+          chipBgColorModifier,
+          chipState,
+          isDisabled,
+        );
       case OudsChipLayout.iconAndText:
-        return _buildIconAndText(context, chipBorderModifier, chipTextColorModifier, chipIconColorModifier, chipBgColorModifier, chipState, isDisabled);
+        return _buildIconAndText(
+          context,
+          chipBorderModifier,
+          chipTextColorModifier,
+          chipIconColorModifier,
+          chipBgColorModifier,
+          chipState,
+          isDisabled,
+        );
       case OudsChipLayout.textOnly:
-        return _buildTextOnly(context, chipBorderModifier, chipTextColorModifier, chipBgColorModifier, chipIconColorModifier, chipState, isDisabled);
+        return _buildTextOnly(
+          context,
+          chipBorderModifier,
+          chipTextColorModifier,
+          chipBgColorModifier,
+          chipIconColorModifier,
+          chipState,
+          isDisabled,
+        );
     }
   }
 

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -115,9 +115,11 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = true;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 

--- a/ouds_core/lib/components/control/ouds_control_item.dart
+++ b/ouds_core/lib/components/control/ouds_control_item.dart
@@ -133,9 +133,11 @@ class OudsControlItemState extends State<OudsControlItem> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = value;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 

--- a/ouds_core/lib/components/radio_button/ouds_radio_button.dart
+++ b/ouds_core/lib/components/radio_button/ouds_radio_button.dart
@@ -102,18 +102,27 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = value;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final interactionModelHover = OudsInheritedInteractionModel.of(context, InteractionAspect.hover);
-    final interactionModelPressed = OudsInheritedInteractionModel.of(context, InteractionAspect.pressed);
+    final interactionModelHover = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.hover,
+    );
+    final interactionModelPressed = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.pressed,
+    );
     final isHoveredInherited = interactionModelHover?.state.isHovered ?? false;
-    final isPressedInherited = interactionModelPressed?.state.isPressed ?? false;
+    final isPressedInherited =
+        interactionModelPressed?.state.isPressed ?? false;
     final isEnabled = widget.onChanged != null;
     final bool isReadOnly = widget.readOnly;
 
@@ -126,15 +135,22 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
 
     final radioButtonState = radioButtonStateDeterminer.determineControlState();
     final radioButtonBorderModifier = OudsControlBorderModifier(context);
-    final radioButtonBackgroundModifier = OudsControlBackgroundModifier(context);
+    final radioButtonBackgroundModifier = OudsControlBackgroundModifier(
+      context,
+    );
     final radioButtonTickModifier = OudsControlTickModifier(context);
-    final radioButton = OudsTheme.of(context).componentsTokens(context).radioButton;
-    final controlItem = OudsTheme.of(context).componentsTokens(context).controlItem;
+    final radioButton = OudsTheme.of(
+      context,
+    ).componentsTokens(context).radioButton;
+    final controlItem = OudsTheme.of(
+      context,
+    ).componentsTokens(context).controlItem;
     final l10n = OudsLocalizations.of(context);
 
     return Semantics(
       enabled: widget.onChanged != null && !(widget.readOnly),
-      label: "${_selected ? l10n?.core_common_selected_a11y : l10n?.core_common_unselected_a11y} "
+      label:
+          "${_selected ? l10n?.core_common_selected_a11y : l10n?.core_common_unselected_a11y} "
           "${l10n?.core_radioButton_radioButton_a11y}",
       value: widget.isError ? l10n?.core_common_error_a11y : null,
       child: SizedBox(
@@ -169,9 +185,15 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
               minWidth: radioButton.sizeMinWidth,
             ),
             decoration: BoxDecoration(
-              color: _isPressed ? radioButtonBackgroundModifier.getBackgroundColor(radioButtonState) : Colors.transparent,
+              color: _isPressed
+                  ? radioButtonBackgroundModifier.getBackgroundColor(
+                      radioButtonState,
+                    )
+                  : Colors.transparent,
               borderRadius: BorderRadius.circular(
-                radioButtonBorderModifier.getBorderRadius(controlItem.borderRadiusItemOnly),
+                radioButtonBorderModifier.getBorderRadius(
+                  controlItem.borderRadiusItemOnly,
+                ),
               ),
             ),
             child: Center(
@@ -185,11 +207,22 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
                     DecoratedBox(
                       decoration: BoxDecoration(
                         border: OudsBorder().borderAll(
-                          color: radioButtonBorderModifier.getBorderColor(radioButtonState, widget.isError, _selected, _isHighContrast),
-                          width: radioButtonBorderModifier.getBorderWidth(radioButtonState, _selected, radioButton),
+                          color: radioButtonBorderModifier.getBorderColor(
+                            radioButtonState,
+                            widget.isError,
+                            _selected,
+                            _isHighContrast,
+                          ),
+                          width: radioButtonBorderModifier.getBorderWidth(
+                            radioButtonState,
+                            _selected,
+                            radioButton,
+                          ),
                         ),
                         borderRadius: BorderRadius.circular(
-                          radioButtonBorderModifier.getBorderRadius(radioButton.borderRadius),
+                          radioButtonBorderModifier.getBorderRadius(
+                            radioButton.borderRadius,
+                          ),
                         ),
                       ),
                     ),
@@ -198,7 +231,9 @@ class OudsRadioButtonState<T> extends State<OudsRadioButton<T>> {
                     if (_selected)
                       Center(
                         child: ClipRRect(
-                          borderRadius: BorderRadius.circular(radioButton.borderRadius),
+                          borderRadius: BorderRadius.circular(
+                            radioButton.borderRadius,
+                          ),
                           child: SvgPicture.asset(
                             AppAssets.icons.componentRadioButtonSelected,
                             excludeFromSemantics: true,

--- a/ouds_core/lib/components/switch/ouds_switch.dart
+++ b/ouds_core/lib/components/switch/ouds_switch.dart
@@ -82,19 +82,31 @@ class _OudsSwitchState extends State<OudsSwitch> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     OudsAccessibilityPlugin.isHighContrastEnabled(context).then((value) {
-      setState(() {
-        _isHighContrast = value;
-      });
+      if (mounted) {
+        setState(() {
+          _isHighContrast = value;
+        });
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final interactionModelHover = OudsInheritedInteractionModel.of(context, InteractionAspect.hover);
-    final interactionModelPressed = OudsInheritedInteractionModel.of(context, InteractionAspect.pressed);
-    final interactionModelFocused = OudsInheritedInteractionModel.of(context, InteractionAspect.focused);
+    final interactionModelHover = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.hover,
+    );
+    final interactionModelPressed = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.pressed,
+    );
+    final interactionModelFocused = OudsInheritedInteractionModel.of(
+      context,
+      InteractionAspect.focused,
+    );
     final isHoveredInherited = interactionModelHover?.state.isHovered ?? false;
-    final isPressedInherited = interactionModelPressed?.state.isPressed ?? false;
+    final isPressedInherited =
+        interactionModelPressed?.state.isPressed ?? false;
     final isFocused = interactionModelFocused?.state.isFocused ?? false;
     final bool isReadOnly = widget.readOnly;
 
@@ -107,7 +119,9 @@ class _OudsSwitchState extends State<OudsSwitch> {
     );
     final switchState = switchStateDeterminer.determineControlState();
     final switchTickModifier = OudsControlTickModifier(context);
-    final switchButton = OudsTheme.of(context).componentsTokens(context).switchButton;
+    final switchButton = OudsTheme.of(
+      context,
+    ).componentsTokens(context).switchButton;
 
     return MergeSemantics(
       child: Semantics(
@@ -157,8 +171,23 @@ class _OudsSwitchState extends State<OudsSwitch> {
                     minWidth: switchButton.sizeMinWidth,
                     maxHeight: switchButton.sizeMaxHeight,
                   ),
-                  decoration: BoxDecoration(borderRadius: BorderRadius.circular(switchButton.borderRadiusTrack), color: switchTickModifier.getBackgroundSwitchColor(switchState, widget.value, _isHighContrast)),
-                  child: _buildCursorIndicator(context, switchState, isPressedInherited, isHoveredInherited, _isHighContrast),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(
+                      switchButton.borderRadiusTrack,
+                    ),
+                    color: switchTickModifier.getBackgroundSwitchColor(
+                      switchState,
+                      widget.value,
+                      _isHighContrast,
+                    ),
+                  ),
+                  child: _buildCursorIndicator(
+                    context,
+                    switchState,
+                    isPressedInherited,
+                    isHoveredInherited,
+                    _isHighContrast,
+                  ),
                 ),
               ),
             ),
@@ -175,7 +204,9 @@ class _OudsSwitchState extends State<OudsSwitch> {
     bool isHovered,
     bool isHighContrast,
   ) {
-    final switchButton = OudsTheme.of(context).componentsTokens(context).switchButton;
+    final switchButton = OudsTheme.of(
+      context,
+    ).componentsTokens(context).switchButton;
     const animationDuration = Duration(milliseconds: 150);
     const customCurve = Cubic(0.2, 0.0, 0.0, 1.0);
     final switchTickModifier = OudsControlTickModifier(context);
@@ -185,7 +216,9 @@ class _OudsSwitchState extends State<OudsSwitch> {
       curve: customCurve,
       width: switchButton.sizeWidthTrack,
       height: switchButton.sizeHeightTrack,
-      padding: widget.value ? EdgeInsets.all(switchButton.spacePaddingInlineSelected) : EdgeInsets.all(switchButton.spacePaddingInlineUnselected),
+      padding: widget.value
+          ? EdgeInsets.all(switchButton.spacePaddingInlineSelected)
+          : EdgeInsets.all(switchButton.spacePaddingInlineUnselected),
       child: AnimatedAlign(
         duration: animationDuration,
         curve: customCurve,
@@ -197,7 +230,9 @@ class _OudsSwitchState extends State<OudsSwitch> {
           height: _getCursorSize(switchButton, isPressed, isHovered).height,
           decoration: BoxDecoration(
             color: switchButton.colorCursor,
-            borderRadius: BorderRadius.circular(switchButton.borderRadiusCursor),
+            borderRadius: BorderRadius.circular(
+              switchButton.borderRadiusCursor,
+            ),
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withAlpha((0.30 * 255).round()),
@@ -216,7 +251,11 @@ class _OudsSwitchState extends State<OudsSwitch> {
                       package: OudsTheme.of(context).packageName,
                       fit: BoxFit.contain,
                       colorFilter: ColorFilter.mode(
-                        switchTickModifier.getTickSwitchColor(switchState, false, isHighContrast),
+                        switchTickModifier.getTickSwitchColor(
+                          switchState,
+                          false,
+                          isHighContrast,
+                        ),
                         BlendMode.srcIn,
                       ),
                     ),
@@ -228,12 +267,24 @@ class _OudsSwitchState extends State<OudsSwitch> {
     );
   }
 
-  Size _getCursorSize(OudsSwitchTokens switchButton, bool isPressed, bool isHover) {
+  Size _getCursorSize(
+    OudsSwitchTokens switchButton,
+    bool isPressed,
+    bool isHover,
+  ) {
     final isActive = _isPressed || isPressed;
 
-    final double width = widget.value ? (isActive ? switchButton.sizeWidthCursorSelectedPressed : switchButton.sizeWidthCursorSelected) : (isActive ? switchButton.sizeWidthCursorUnselectedPressed : switchButton.sizeWidthCursorUnselected);
+    final double width = widget.value
+        ? (isActive
+              ? switchButton.sizeWidthCursorSelectedPressed
+              : switchButton.sizeWidthCursorSelected)
+        : (isActive
+              ? switchButton.sizeWidthCursorUnselectedPressed
+              : switchButton.sizeWidthCursorUnselected);
 
-    final double height = widget.value ? switchButton.sizeHeightCursorSelected : switchButton.sizeHeightCursorUnselected;
+    final double height = widget.value
+        ? switchButton.sizeHeightCursorSelected
+        : switchButton.sizeHeightCursorUnselected;
 
     return Size(width, height);
   }

--- a/ouds_core/test/components/mounted_guard_test.dart
+++ b/ouds_core/test/components/mounted_guard_test.dart
@@ -1,0 +1,175 @@
+/*
+ * // Software Name: OUDS Flutter
+ * // SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * // SPDX-License-Identifier: MIT
+ * //
+ * // This software is distributed under the MIT license,
+ * // the text of which is available at https://opensource.org/license/MIT/
+ * // or see the "LICENSE" file for more details.
+ * //
+ * // Software description: Flutter library of reusable graphical components
+ * //
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ouds_core/components/checkbox/ouds_checkbox.dart'
+    show OudsCheckbox;
+import 'package:ouds_core/components/chip/ouds_filter_chip.dart'
+    show OudsFilterChip;
+import 'package:ouds_core/components/chip/ouds_suggestion_chip.dart'
+    show OudsSuggestionChip;
+import 'package:ouds_core/components/radio_button/ouds_radio_button.dart'
+    show OudsRadioButton;
+import 'package:ouds_core/components/switch/ouds_switch.dart' show OudsSwitch;
+
+/// Wraps a widget with the minimum setup required for widget tests.
+Widget _testableWidget(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+/// Regression tests for the "Null check operator used on a null value" crash.
+///
+/// The bug occurred when a component with an async `didChangeDependencies`
+/// callback (calling `OudsAccessibilityPlugin.isHighContrastEnabled`) was
+/// disposed before the Future completed, causing `setState` on an unmounted
+/// State. The fix adds a `if (mounted)` guard before `setState`.
+///
+/// These tests verify that quickly removing each component from the tree
+/// does NOT throw "Null check operator used on a null value".
+void main() {
+  group('Mounted guard - no setState after dispose', () {
+    testWidgets('OudsRadioButton does not crash when disposed quickly', (
+      tester,
+    ) async {
+      // Track if "Null check operator" error occurs (the crash we fixed).
+      String? nullCheckError;
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('Null check operator')) {
+          nullCheckError = details.exceptionAsString();
+        }
+      };
+
+      await tester.pumpWidget(
+        _testableWidget(
+          OudsRadioButton<int>(value: 1, groupValue: 1, onChanged: (_) {}),
+        ),
+      );
+
+      await tester.pumpWidget(_testableWidget(const SizedBox.shrink()));
+      await tester.pump(const Duration(seconds: 1));
+
+      FlutterError.onError = originalOnError;
+      expect(
+        nullCheckError,
+        isNull,
+        reason: 'setState was called after dispose',
+      );
+    });
+
+    testWidgets('OudsCheckbox does not crash when disposed quickly', (
+      tester,
+    ) async {
+      String? nullCheckError;
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('Null check operator')) {
+          nullCheckError = details.exceptionAsString();
+        }
+      };
+
+      await tester.pumpWidget(
+        _testableWidget(OudsCheckbox(value: true, onChanged: (_) {})),
+      );
+
+      await tester.pumpWidget(_testableWidget(const SizedBox.shrink()));
+      await tester.pump(const Duration(seconds: 1));
+
+      FlutterError.onError = originalOnError;
+      expect(
+        nullCheckError,
+        isNull,
+        reason: 'setState was called after dispose',
+      );
+    });
+
+    testWidgets('OudsSwitch does not crash when disposed quickly', (
+      tester,
+    ) async {
+      String? nullCheckError;
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('Null check operator')) {
+          nullCheckError = details.exceptionAsString();
+        }
+      };
+
+      await tester.pumpWidget(
+        _testableWidget(OudsSwitch(value: true, onChanged: (_) {})),
+      );
+
+      await tester.pumpWidget(_testableWidget(const SizedBox.shrink()));
+      await tester.pump(const Duration(seconds: 1));
+
+      FlutterError.onError = originalOnError;
+      expect(
+        nullCheckError,
+        isNull,
+        reason: 'setState was called after dispose',
+      );
+    });
+
+    testWidgets('OudsSuggestionChip does not crash when disposed quickly', (
+      tester,
+    ) async {
+      String? nullCheckError;
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('Null check operator')) {
+          nullCheckError = details.exceptionAsString();
+        }
+      };
+
+      await tester.pumpWidget(
+        _testableWidget(OudsSuggestionChip(label: 'Test', onPressed: () {})),
+      );
+
+      await tester.pumpWidget(_testableWidget(const SizedBox.shrink()));
+      await tester.pump(const Duration(seconds: 1));
+
+      FlutterError.onError = originalOnError;
+      expect(
+        nullCheckError,
+        isNull,
+        reason: 'setState was called after dispose',
+      );
+    });
+
+    testWidgets('OudsFilterChip does not crash when disposed quickly', (
+      tester,
+    ) async {
+      String? nullCheckError;
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('Null check operator')) {
+          nullCheckError = details.exceptionAsString();
+        }
+      };
+
+      await tester.pumpWidget(
+        _testableWidget(OudsFilterChip(label: 'Test', onSelected: (_) {})),
+      );
+
+      await tester.pumpWidget(_testableWidget(const SizedBox.shrink()));
+      await tester.pump(const Duration(seconds: 1));
+
+      FlutterError.onError = originalOnError;
+      expect(
+        nullCheckError,
+        isNull,
+        reason: 'setState was called after dispose',
+      );
+    });
+  });
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/DEVELOP.md)
- [x] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [ ] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] CHANGELOG.md files have been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
