### PR TITLE
chore : add size parameter to OudsCircularProgressIndicator

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.1.0...develop)
 ### Added
 ### Changed
+- [DemoApp][Library] Update `progress-indicator`: add size parameter to OudsCircularProgressIndicator for button integration ([#876](https://github.com/Orange-OpenSource/ouds-flutter/issues/876))
 ### Fixed
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.0.0...2.1.0) - 2026-08-07

--- a/app/lib/ui/components/components.dart
+++ b/app/lib/ui/components/components.dart
@@ -390,7 +390,7 @@ List<Component> components(BuildContext context) {
       context.l10n.app_components_progressIndicator_tech,
       ComponentContainer(
         child: OudsCircularProgressIndicator(
-          progress: 0.75,
+          value: 0.75,
           status: Accent(),
           animated: false,
         ),

--- a/app/lib/ui/components/progress_indicator/circular_progress_indicator_demo_screen.dart
+++ b/app/lib/ui/components/progress_indicator/circular_progress_indicator_demo_screen.dart
@@ -153,26 +153,55 @@ class _CircularProgressIndicatorDemoState
     customizationState = ProgressIndicatorCustomization.of(context);
     themeController = Provider.of<ThemeController>(context, listen: true);
 
-    return LightDarkBox(
-      child: OudsCircularProgressIndicator(
-        progressType: ProgressIndicatorCustomizationUtils.getProgressType(
-          customizationState!.selectedType,
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
+
+    if (customizationState?.hasOnColoredBox == true) {
+      return ComponentDemoBox(
+        colored: customizationState?.hasOnColoredBox == true,
+        child: OudsCircularProgressIndicator(
+          progressType: ProgressIndicatorCustomizationUtils.getProgressType(
+            customizationState!.selectedType,
+          ),
+          status: ProgressIndicatorCustomizationUtils.getStatus(
+            customizationState!.selectedStatus,
+          ),
+          value: ProgressIndicatorCustomizationUtils.getProgressValue(
+            customizationState!.value,
+          ),
+          track: customizationState!.hasTrack,
+          animated: customizationState!.hasAnimation,
+          gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
+            customizationState!.selectedGapSize,
+          ),
+          semanticLabel:
+              context.l10n.app_components_progressIndicator_progress_a11y,
         ),
-        status: ProgressIndicatorCustomizationUtils.getStatus(
-          customizationState!.selectedStatus,
+      );
+    } else {
+      return LightDarkBox(
+        child: OudsCircularProgressIndicator(
+          progressType: ProgressIndicatorCustomizationUtils.getProgressType(
+            customizationState!.selectedType,
+          ),
+          status: ProgressIndicatorCustomizationUtils.getStatus(
+            customizationState!.selectedStatus,
+          ),
+          value: ProgressIndicatorCustomizationUtils.getProgressValue(
+            customizationState!.value,
+          ),
+          track: customizationState!.hasTrack,
+          animated: customizationState!.hasAnimation,
+          gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
+            customizationState!.selectedGapSize,
+          ),
+          semanticLabel:
+              context.l10n.app_components_progressIndicator_progress_a11y,
         ),
-        progress: ProgressIndicatorCustomizationUtils.getProgressValue(
-          customizationState!.progress,
-        ),
-        track: customizationState!.hasTrack,
-        animated: customizationState!.hasAnimation,
-        gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
-          customizationState!.selectedGapSize,
-        ),
-        semanticLabel:
-            context.l10n.app_components_progressIndicator_progress_a11y,
-      ),
-    );
+      );
+    }
   }
 }
 
@@ -219,9 +248,16 @@ class _CustomizationContentState extends State<_CustomizationContent> {
             });
           },
         ),
+        CustomizableSwitch(
+          title: context.l10n.app_components_common_onColoredBackground_label,
+          value: customizationState.hasOnColoredBox,
+          onChanged: (value) {
+            customizationState.hasOnColoredBox = value;
+          },
+        ),
         CustomizableTextField(
           title: context.l10n.app_components_progressIndicator_progress_tech,
-          text: customizationState.progress.toString(),
+          text: customizationState.value.toString(),
           focusNode: progressFocus,
           fieldType: FieldType.label,
           fieldEnable:
@@ -232,6 +268,9 @@ class _CustomizationContentState extends State<_CustomizationContent> {
         CustomizationDropdownMenu<StatusEnum>(
           label: StatusEnum.enumName(context),
           options: customizationState.statusState.list,
+          disabledOptions: customizationState.hasOnColoredBox
+              ? customizationState.statusState.list
+              : null,
           selectedItemIndex: customizationState.selectedIndex,
           selectedOption: customizationState.selectedStatus,
           getText: (option) => option.stringValue(context),

--- a/app/lib/ui/components/progress_indicator/linear_progress_indicator_demo_screen.dart
+++ b/app/lib/ui/components/progress_indicator/linear_progress_indicator_demo_screen.dart
@@ -154,39 +154,79 @@ class _LinearProgressIndicatorDemoState
   Widget build(BuildContext context) {
     customizationState = ProgressIndicatorCustomization.of(context);
     themeController = Provider.of<ThemeController>(context, listen: true);
+    // Adding post-frame callback to update theme based on customization state
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      themeController?.setOnColoredSurface(customizationState?.hasOnColoredBox);
+    });
 
-    return LightDarkBox(
-      child: OudsLinearProgressIndicator(
-        progressType: ProgressIndicatorCustomizationUtils.getProgressType(
-          customizationState!.selectedType,
+    if (customizationState?.hasOnColoredBox == true) {
+      return ComponentDemoBox(
+        colored: customizationState?.hasOnColoredBox == true,
+        child: OudsLinearProgressIndicator(
+          progressType: ProgressIndicatorCustomizationUtils.getProgressType(
+            customizationState!.selectedType,
+          ),
+          status: ProgressIndicatorCustomizationUtils.getStatus(
+            customizationState!.selectedStatus,
+          ),
+          value: ProgressIndicatorCustomizationUtils.getProgressValue(
+            customizationState!.value,
+          ),
+          track: customizationState!.hasTrack,
+          animated: customizationState!.hasAnimation,
+          gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
+            customizationState!.selectedGapSize,
+          ),
+          stopIndicator: customizationState!.hasStopIndicator,
+          percentage: customizationState!.hasHelperText
+              ? customizationState!.hasPercentage
+              : false,
+          spaceBeforePercentage: customizationState!.hasSpaceBefore,
+          helperTextAlignment:
+              ProgressIndicatorCustomizationUtils.getHelperTextAlignment(
+                customizationState!.selectedAlignment,
+              ),
+          helperText: customizationState!.hasHelperText
+              ? customizationState!.helperText
+              : null,
+          semanticLabel:
+              context.l10n.app_components_progressIndicator_progress_a11y,
         ),
-        status: ProgressIndicatorCustomizationUtils.getStatus(
-          customizationState!.selectedStatus,
+      );
+    } else {
+      return LightDarkBox(
+        child: OudsLinearProgressIndicator(
+          progressType: ProgressIndicatorCustomizationUtils.getProgressType(
+            customizationState!.selectedType,
+          ),
+          status: ProgressIndicatorCustomizationUtils.getStatus(
+            customizationState!.selectedStatus,
+          ),
+          value: ProgressIndicatorCustomizationUtils.getProgressValue(
+            customizationState!.value,
+          ),
+          track: customizationState!.hasTrack,
+          animated: customizationState!.hasAnimation,
+          gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
+            customizationState!.selectedGapSize,
+          ),
+          stopIndicator: customizationState!.hasStopIndicator,
+          percentage: customizationState!.hasHelperText
+              ? customizationState!.hasPercentage
+              : false,
+          spaceBeforePercentage: customizationState!.hasSpaceBefore,
+          helperTextAlignment:
+              ProgressIndicatorCustomizationUtils.getHelperTextAlignment(
+                customizationState!.selectedAlignment,
+              ),
+          helperText: customizationState!.hasHelperText
+              ? customizationState!.helperText
+              : null,
+          semanticLabel:
+              context.l10n.app_components_progressIndicator_progress_a11y,
         ),
-        progress: ProgressIndicatorCustomizationUtils.getProgressValue(
-          customizationState!.progress,
-        ),
-        track: customizationState!.hasTrack,
-        animated: customizationState!.hasAnimation,
-        gapSize: ProgressIndicatorCustomizationUtils.getGapSize(
-          customizationState!.selectedGapSize,
-        ),
-        stopIndicator: customizationState!.hasStopIndicator,
-        percentage: customizationState!.hasHelperText
-            ? customizationState!.hasPercentage
-            : false,
-        spaceBeforePercentage: customizationState!.hasSpaceBefore,
-        helperTextAlignment:
-            ProgressIndicatorCustomizationUtils.getHelperTextAlignment(
-              customizationState!.selectedAlignment,
-            ),
-        helperText: customizationState!.hasHelperText
-            ? customizationState!.helperText
-            : null,
-        semanticLabel:
-            context.l10n.app_components_progressIndicator_progress_a11y,
-      ),
-    );
+      );
+    }
   }
 }
 
@@ -237,9 +277,16 @@ class _CustomizationContentState extends State<_CustomizationContent> {
             });
           },
         ),
+        CustomizableSwitch(
+          title: context.l10n.app_components_common_onColoredBackground_label,
+          value: customizationState.hasOnColoredBox,
+          onChanged: (value) {
+            customizationState.hasOnColoredBox = value;
+          },
+        ),
         CustomizableTextField(
           title: context.l10n.app_components_progressIndicator_progress_tech,
-          text: customizationState.progress.toString(),
+          text: customizationState.value.toString(),
           focusNode: progressFocus,
           fieldType: FieldType.label,
           fieldEnable:

--- a/app/lib/ui/components/progress_indicator/progress_indicator_code_generator.dart
+++ b/app/lib/ui/components/progress_indicator/progress_indicator_code_generator.dart
@@ -28,10 +28,12 @@ class ProgressIndicatorCodeGenerator {
         ? "OudsCircularProgressIndicator"
         : "OudsLinearProgressIndicator";
 
+    final customizationState = ProgressIndicatorCustomization.of(context);
+
     final params = <String>[
       progressType(context),
-      status(context),
-      progress(context),
+      if (customizationState?.hasOnColoredBox != true) status(context),
+      value(context),
       track(context),
       animated(context),
       gapSize(context),
@@ -45,9 +47,26 @@ class ProgressIndicatorCodeGenerator {
       ],
     ];
 
-    return """$widgetName(
+    return """${coloredSurfaceCodeModifier(context)}$widgetName(
   ${params.join(",\n  ")},
-)""";
+)${coloredSurfaceCodeModifierEnd(context)}""";
+  }
+
+  // Returns the `OudsColoredBox(` opening wrapper when the colored box is enabled.
+  static String coloredSurfaceCodeModifier(BuildContext context) {
+    final customizationState = ProgressIndicatorCustomization.of(context);
+
+    if (customizationState?.hasOnColoredBox == true) {
+      return "OudsColoredBox(\ncolor: OudsColoredBoxColor.brandPrimary,\nchild: ";
+    }
+
+    return "";
+  }
+
+  // Closes the `OudsColoredBox(` wrapper opened by [coloredSurfaceCodeModifier], if any.
+  static String coloredSurfaceCodeModifierEnd(BuildContext context) {
+    final customizationState = ProgressIndicatorCustomization.of(context);
+    return customizationState?.hasOnColoredBox == true ? ",\n)" : "";
   }
 
   static String progressType(BuildContext context) {
@@ -66,14 +85,14 @@ class ProgressIndicatorCodeGenerator {
     return "status: ${_getStatusCode(customizationState!)}";
   }
 
-  static String progress(BuildContext context) {
+  static String value(BuildContext context) {
     final customizationState = ProgressIndicatorCustomization.of(context);
 
     if (customizationState?.selectedType ==
         ProgressIndicatorEnumType.indeterminate) {
-      return "progress: null";
+      return "value: null";
     } else {
-      return "progress: ${customizationState?.progress}";
+      return "value: ${customizationState?.value}";
     }
   }
 
@@ -96,11 +115,11 @@ class ProgressIndicatorCodeGenerator {
   static String semanticLabel(BuildContext context) {
     final customizationState = ProgressIndicatorCustomization.of(context);
 
-    final hasProgress =
-        customizationState!.progress.isNotEmpty &&
-        (double.tryParse(customizationState.progress) ?? 0.0) > 0.0;
+    final hasValue =
+        customizationState!.value.isNotEmpty &&
+        (double.tryParse(customizationState.value) ?? 0.0) > 0.0;
 
-    return "semanticLabel: '${hasProgress ? "Uploading file" : "Connecting to server"}'";
+    return "semanticLabel: '${hasValue ? "Uploading file" : "Connecting to server"}'";
   }
 
   static String stopIndicator(BuildContext context) {

--- a/app/lib/ui/components/progress_indicator/progress_indicator_customization.dart
+++ b/app/lib/ui/components/progress_indicator/progress_indicator_customization.dart
@@ -40,7 +40,7 @@ class ProgressIndicatorCustomization extends StatefulWidget {
 /// tag customization state management
 class ProgressIndicatorCustomizationState
     extends CustomizationWidgetState<ProgressIndicatorCustomization> {
-  late final ProgressState progressState;
+  late final ValueState valueState;
   late final SizeState sizeState;
   late final StatusState statusState;
   late final TrackState trackState;
@@ -56,7 +56,7 @@ class ProgressIndicatorCustomizationState
   @override
   void initState() {
     super.initState();
-    progressState = ProgressState(setState);
+    valueState = ValueState(setState);
     sizeState = SizeState(setState);
     statusState = StatusState(setState);
     trackState = TrackState(setState);
@@ -70,8 +70,8 @@ class ProgressIndicatorCustomizationState
     spaceBeforeState = SpaceBeforeState(setState);
   }
 
-  String get progress => progressState.value;
-  set progress(String value) => progressState.value = value;
+  String get value => valueState.value;
+  set value(String value) => valueState.value = value;
 
   LinkEnumSize get selectedSize => sizeState.selected;
   set selectedSize(LinkEnumSize value) => sizeState.selected = value;
@@ -129,8 +129,8 @@ class ProgressIndicatorCustomizationState
 }
 
 /// progress value State Management
-class ProgressState {
-  ProgressState(this._setState);
+class ValueState {
+  ValueState(this._setState);
 
   final void Function(void Function()) _setState;
   String _progressValue = "0.75";

--- a/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
+++ b/app/lib/ui/utilities/customizable/customizable_dropdown_menu.dart
@@ -24,7 +24,7 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
   final List<Widget Function()>? itemLeadingIcons;
   final T? selectedOption;
   final bool isSelected;
-  final T? disabledOption;
+  final List<T>? disabledOptions;
 
   const CustomizationDropdownMenu({
     super.key,
@@ -36,12 +36,15 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
     this.itemLeadingIcons,
     required this.getText,
     this.isSelected = false,
-    this.disabledOption,
+    this.disabledOptions,
   });
 
   @override
   Widget build(BuildContext context) {
-    final themeController = Provider.of<ThemeController>(context, listen: false);
+    final themeController = Provider.of<ThemeController>(
+      context,
+      listen: false,
+    );
     final currentTheme = themeController.currentTheme;
 
     return Column(
@@ -49,7 +52,9 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
       children: [
         ExcludeSemantics(
           child: Padding(
-            padding: EdgeInsetsDirectional.symmetric(horizontal: currentTheme.spaceScheme(context).fixedMedium),
+            padding: EdgeInsetsDirectional.symmetric(
+              horizontal: currentTheme.spaceScheme(context).fixedMedium,
+            ),
             child: Text(
               label,
               style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
@@ -67,35 +72,54 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
               initialSelection: options[selectedItemIndex],
               expandedInsets: EdgeInsets.zero,
               inputDecorationTheme: const InputDecorationTheme(isDense: true),
-              textStyle: currentTheme.typographyTokens.typeBodyStrongLarge(context),
-              onSelected:  (value) {
+              textStyle: currentTheme.typographyTokens.typeBodyStrongLarge(
+                context,
+              ),
+              onSelected: (value) {
                 if (value != null) {
                   final newIndex = options.indexOf(value);
                   onSelectionChange(value, newIndex);
                 }
               },
-              leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, selectedItemIndex) : null,
-              dropdownMenuEntries: List.generate(
-                options.length,
-                (index) {
-                  T currentElement = options[index];
-                  final isSelected = currentElement == options[selectedItemIndex];
-                  return DropdownMenuEntry<T>(
-                    enabled: currentElement == disabledOption ? false : true,
-                    labelWidget: Semantics(
-                      button: true,
-                      value: isSelected ? context.l10n.app_common_selected_a11y : context.l10n.app_common_unselected_a11y,
-                      child: Text(
-                        getText(currentElement),
-                        style: currentTheme.typographyTokens.typeBodyStrongLarge(context),
+              leadingIcon: itemLeadingIcons != null
+                  ? buildDropdownLeadingIcon(
+                      context,
+                      itemLeadingIcons,
+                      selectedItemIndex,
+                    )
+                  : null,
+              dropdownMenuEntries: List.generate(options.length, (index) {
+                T currentElement = options[index];
+                final isSelected = currentElement == options[selectedItemIndex];
+                return DropdownMenuEntry<T>(
+                  enabled:
+                      disabledOptions != null &&
+                          disabledOptions!.contains(currentElement)
+                      ? false
+                      : true,
+                  labelWidget: Semantics(
+                    button: true,
+                    value: isSelected
+                        ? context.l10n.app_common_selected_a11y
+                        : context.l10n.app_common_unselected_a11y,
+                    child: Text(
+                      getText(currentElement),
+                      style: currentTheme.typographyTokens.typeBodyStrongLarge(
+                        context,
                       ),
                     ),
-                    value: currentElement,
-                    label: getText(currentElement),
-                    leadingIcon: itemLeadingIcons != null ? buildDropdownLeadingIcon(context, itemLeadingIcons, index) : null,
-                  );
-                },
-              ),
+                  ),
+                  value: currentElement,
+                  label: getText(currentElement),
+                  leadingIcon: itemLeadingIcons != null
+                      ? buildDropdownLeadingIcon(
+                          context,
+                          itemLeadingIcons,
+                          index,
+                        )
+                      : null,
+                );
+              }),
             ),
           ),
         ),
@@ -103,9 +127,18 @@ class CustomizationDropdownMenu<T> extends StatelessWidget {
     );
   }
 
-  Widget? buildDropdownLeadingIcon(BuildContext context, List<Widget Function()>? builders, int index) {
+  Widget? buildDropdownLeadingIcon(
+    BuildContext context,
+    List<Widget Function()>? builders,
+    int index,
+  ) {
     if (builders != null && index < builders.length) {
-      return Padding(padding: EdgeInsetsDirectional.all(OudsTheme.of(context).spaceScheme(context).paddingInlineSmall), child: builders[index]());
+      return Padding(
+        padding: EdgeInsetsDirectional.all(
+          OudsTheme.of(context).spaceScheme(context).paddingInlineSmall,
+        ),
+        child: builders[index](),
+      );
     }
     return null;
   }

--- a/app/lib/ui/utilities/customizable/customizable_textfield.dart
+++ b/app/lib/ui/utilities/customizable/customizable_textfield.dart
@@ -133,7 +133,7 @@ class CustomizableTextFieldState extends State<CustomizableTextField> {
         topBarState?.previousPageTitleText = value;
         linkState?.labelText = value;
         alertMessageState?.label = value;
-        progressIndicatorState?.progress = value;
+        progressIndicatorState?.value = value;
         break;
       case FieldType.helper:
         textInputState?.helperText = value;

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - [Library] Update `progress-indicator`: add size parameter to OudsCircularProgressIndicator for button integration ([#876](https://github.com/Orange-OpenSource/ouds-flutter/issues/876))
-
 ### Fixed
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.0.0...2.1.0) - 2026-08-07

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.1.0...develop)
 ### Added
 ### Changed
+- [Library] Update `progress-indicator`: add size parameter to OudsCircularProgressIndicator for button integration ([#876](https://github.com/Orange-OpenSource/ouds-flutter/issues/876))
+
 ### Fixed
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.0.0...2.1.0) - 2026-08-07

--- a/ouds_core/lib/components/progress_indicator/internal/ouds_progress_indicator_status_modifier.dart
+++ b/ouds_core/lib/components/progress_indicator/internal/ouds_progress_indicator_status_modifier.dart
@@ -26,7 +26,11 @@ class OudsProgressIndicatorStatusModifier {
   /// Returns the indicator color based on the progress indicator status.
   Color getStatusColor(OudsIconStatus status) {
     final colorTheme = OudsTheme.of(context).colorScheme(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
 
+    if (onColoredSurface) {
+      return colorTheme.contentDefault;
+    }
     return switch (status) {
       Neutral() => colorTheme.contentDefault,
       Accent() => colorTheme.contentStatusAccent,

--- a/ouds_core/lib/components/progress_indicator/internal/ouds_progress_indicator_style_modifier.dart
+++ b/ouds_core/lib/components/progress_indicator/internal/ouds_progress_indicator_style_modifier.dart
@@ -71,11 +71,6 @@ class OudsProgressIndicatorStyleModifier {
     return gapSizeType == OudsProgressIndicatorGapSize.defaultSize ? 4.0 : 1.0;
   }
 
-  /// Calculates the stroke width: 12.5% of the diameter.
-  double computeStrokeWidth(double componentSize) {
-    return componentSize * 0.125;
-  }
-
   /// Determines the stroke cap style based on the border radius and gap size.
   StrokeCap getStrokeCap(OudsProgressIndicatorGapSize gapSizeType) {
     final radius = getDoubleBorderRadius();

--- a/ouds_core/lib/components/progress_indicator/ouds_progress_indicator.dart
+++ b/ouds_core/lib/components/progress_indicator/ouds_progress_indicator.dart
@@ -12,6 +12,7 @@
 /// {@category Progress indicator}
 library;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:ouds_core/components/common/ouds_icon_status.dart';
 import 'package:ouds_core/components/progress_indicator/internal/ouds_progress_indicator_status_modifier.dart';
@@ -47,7 +48,7 @@ const _animationDuration = Duration(milliseconds: 800);
 abstract class OudsProgressIndicator extends StatefulWidget {
   /// Creates a progress indicator.
   ///
-  /// The [progress] value must be between `0.0` and `1.0` when [progressType]
+  /// The [value] value must be between `0.0` and `1.0` when [progressType]
   /// is [OudsProgressIndicatorType.determinate]; it is ignored otherwise.
   ///
   /// ## Accessibility
@@ -59,7 +60,7 @@ abstract class OudsProgressIndicator extends StatefulWidget {
     this.progressType = OudsProgressIndicatorType.determinate,
     this.status = const Neutral(),
     this.animated = true,
-    this.progress,
+    this.value,
     this.gapSize = OudsProgressIndicatorGapSize.defaultSize,
     this.track = true,
     this.semanticLabel,
@@ -68,7 +69,7 @@ abstract class OudsProgressIndicator extends StatefulWidget {
   final OudsProgressIndicatorType? progressType;
   final OudsIconStatus status;
   final bool animated;
-  final double? progress;
+  final double? value;
   final OudsProgressIndicatorGapSize gapSize;
   final bool track;
   final String? semanticLabel;
@@ -92,7 +93,7 @@ abstract class OudsProgressIndicator extends StatefulWidget {
 ///   when the operation carries a meaning.
 /// - [animated]: Enables smooth value-change animation (determinate only).
 ///   Automatically disabled when the OS reduced-motion setting is on.
-/// - [progress]: Value between `0.0` and `1.0`. Pass `null` for indeterminate.
+/// - [value]: Value between `0.0` and `1.0`. Pass `null` for indeterminate.
 /// - [gapSize]: Gap between the active arc and its track — [OudsProgressIndicatorGapSize].
 /// - [track]: Whether the background track ring is visible.
 /// - [semanticLabel]: Accessibility label for assistive technologies.
@@ -103,7 +104,7 @@ abstract class OudsProgressIndicator extends StatefulWidget {
 /// OudsCircularProgressIndicator(
 ///   progressType: OudsProgressIndicatorType.determinate,
 ///   status: Positive(),
-///   progress: 0.8,
+///   value: 0.8,
 ///   track: false,
 ///   animated: true,
 ///   gapSize: OudsProgressIndicatorGapSize.small,
@@ -115,11 +116,48 @@ class OudsCircularProgressIndicator extends OudsProgressIndicator {
     super.progressType = OudsProgressIndicatorType.determinate,
     super.status = const Neutral(),
     super.animated = true,
-    super.progress,
+    super.value,
     super.gapSize = OudsProgressIndicatorGapSize.defaultSize,
     super.track = true,
     super.semanticLabel,
-  });
+  }) : _color = null,
+       _size = _oudsCircularProgressIndicatorSize;
+
+  /// Creates an [OudsCircularProgressIndicator] with an explicit [color], bypassing the
+  /// [status]-based color resolution.
+  ///
+  /// This constructor is **internal** and reserved for other OUDS components (e.g. [OudsButton])
+  /// that need to render the indicator using a color coming from their own token resolution
+  /// (which may not map to any of the semantic [OudsIconStatus] values).
+  ///
+  /// Do not use this constructor directly from application code — use the default constructor
+  /// with [status] instead.
+  @internal
+  const OudsCircularProgressIndicator.internal({
+    super.key,
+    super.progressType = OudsProgressIndicatorType.determinate,
+    super.animated = true,
+    super.value,
+    super.gapSize = OudsProgressIndicatorGapSize.defaultSize,
+    super.track = true,
+    super.semanticLabel,
+    Color? color,
+    double? size,
+  }) : _color = color,
+       _size = size;
+
+  /// Explicit color override used instead of resolving [OudsProgressIndicator.status].
+  ///
+  /// `null` when created via the public constructor, in which case [status] is used.
+  final Color? _color;
+
+  /// Explicit diameter override (in pixels, before text-scale) used instead of
+  /// [_oudsCircularProgressIndicatorSize].
+  ///
+  /// `null` when created via the public constructor, in which case the default size is used.
+  /// The stroke width is scaled proportionally to this size so the indicator doesn't look
+  /// disproportionately thick when rendered smaller than the default size (e.g. inside a button).
+  final double? _size;
 
   @override
   State<OudsCircularProgressIndicator> createState() =>
@@ -134,12 +172,14 @@ class _OudsCircularProgressIndicatorState
     final statusModifier = OudsProgressIndicatorStatusModifier(context);
     final textScaler = MediaQuery.textScalerOf(context);
 
-    final defaultSize = textScaler.scale(_oudsCircularProgressIndicatorSize);
+    final indicatorSize = widget._size ?? _oudsCircularProgressIndicatorSize;
+    final defaultSize = textScaler.scale(indicatorSize);
     final progressValue = OudsProgressIndicatorUtils.clampedProgressValue(
       widget.progressType,
-      widget.progress,
+      widget.value,
     );
-    final indicatorColor = statusModifier.getStatusColor(widget.status);
+    final indicatorColor =
+        widget._color ?? statusModifier.getStatusColor(widget.status);
     final backgroundColor = styleModifier.getTrackColor(widget.track);
     final strokeWidth = styleModifier.computeStrokeWidth(defaultSize);
     final gapSize = styleModifier.computeGapSize(widget.gapSize);
@@ -156,7 +196,7 @@ class _OudsCircularProgressIndicatorState
 
     final semanticsValue = OudsProgressIndicatorUtils.buildSemanticValueLabel(
       widget.progressType,
-      widget.progress,
+      widget.value,
       OudsLocalizations.of(context),
     );
 
@@ -206,6 +246,10 @@ class _OudsCircularProgressIndicatorState
   /// Builds the underlying [CircularProgressIndicator] widget with the
   /// already computed visual properties.
   ///
+  /// Wraps the indicator in a [SizedBox] to enforce [defaultSize],
+  /// preventing the parent constraints (e.g. a button) from shrinking
+  /// or expanding the indicator unexpectedly.
+  ///
   /// This helper avoids duplicating the widget tree between animated and
   /// non-animated rendering paths.
   Widget _buildIndicator({
@@ -222,6 +266,9 @@ class _OudsCircularProgressIndicatorState
   }) {
     final bool indeterminateWithReduceMotion =
         value == null && reduceMotion == true;
+
+    // SizedBox enforces the computed or custom size,
+    // preventing parent constraints from altering the indicator dimensions.
     return Transform.rotate(
       angle: indeterminateWithReduceMotion ? 20 : 0,
       child: indeterminateWithReduceMotion
@@ -229,6 +276,7 @@ class _OudsCircularProgressIndicatorState
               label: semanticsLabel,
               child: ExcludeSemantics(
                 child: CircularProgressIndicator(
+                  padding: EdgeInsets.zero,
                   year2023: false,
                   constraints: BoxConstraints(
                     minWidth: defaultSize,
@@ -244,6 +292,7 @@ class _OudsCircularProgressIndicatorState
               ),
             )
           : CircularProgressIndicator(
+              padding: EdgeInsets.zero,
               semanticsLabel: semanticsLabel,
               semanticsValue: semanticsValue,
               year2023: false,
@@ -282,7 +331,7 @@ class _OudsCircularProgressIndicatorState
 ///   when the operation carries a meaning.
 /// - [animated]: Enables smooth value-change animation (determinate only).
 ///   Automatically disabled when the OS reduced-motion setting is on.
-/// - [progress]: Value between `0.0` and `1.0`. Pass `null` for indeterminate.
+/// - [value]: Value between `0.0` and `1.0`. Pass `null` for indeterminate.
 /// - [gapSize]: Gap between the active bar and its track — [OudsProgressIndicatorGapSize].
 /// - [track]: Whether the background track bar is visible.
 /// - [semanticLabel]: Accessibility label for assistive technologies.
@@ -291,7 +340,7 @@ class _OudsCircularProgressIndicatorState
 /// - [helperText]: Optional text displayed below the indicator.
 /// - [helperTextAlignment]: Horizontal alignment of the helper text —
 ///   [OudsProgressIndicatorHelperTextAlignment].
-/// - [percentage]: When `true`, the helper text is generated from [progress]
+/// - [percentage]: When `true`, the helper text is generated from [value]
 ///   and formatted as a percentage; when `false`, [helperText] is used.
 /// - [spaceBeforePercentage]: Inserts a non-breaking space before the `%`
 ///   symbol when [percentage] is `true` (e.g. `75 %` instead of `75%`).
@@ -340,7 +389,7 @@ class OudsLinearProgressIndicator extends OudsProgressIndicator {
     super.progressType = OudsProgressIndicatorType.determinate,
     super.status = const Neutral(),
     super.animated = true,
-    super.progress,
+    super.value,
     super.gapSize = OudsProgressIndicatorGapSize.defaultSize,
     super.track = true,
     super.semanticLabel,
@@ -398,7 +447,7 @@ class _OudsLinearProgressIndicatorState
     final helperTextLabel = OudsProgressIndicatorUtils.buildHelperText(
       widget.percentage,
       widget.spaceBeforePercentage,
-      widget.progress,
+      widget.value,
       widget.helperText,
     );
     return helperTextLabel != null && helperTextLabel.isNotEmpty
@@ -450,7 +499,7 @@ class _OudsLinearProgressIndicatorState
 
     final progressValue = OudsProgressIndicatorUtils.clampedProgressValue(
       widget.progressType,
-      widget.progress,
+      widget.value,
     );
 
     final borderRadius = progressIndicatorStyleModifier.getBorderRadius();
@@ -466,7 +515,7 @@ class _OudsLinearProgressIndicatorState
 
     final semanticsValue = OudsProgressIndicatorUtils.buildSemanticValueLabel(
       widget.progressType,
-      widget.progress,
+      widget.value,
       OudsLocalizations.of(context),
     );
 

--- a/ouds_core/lib/components/progress_indicator/ouds_progress_indicator.dart
+++ b/ouds_core/lib/components/progress_indicator/ouds_progress_indicator.dart
@@ -120,8 +120,7 @@ class OudsCircularProgressIndicator extends OudsProgressIndicator {
     super.gapSize = OudsProgressIndicatorGapSize.defaultSize,
     super.track = true,
     super.semanticLabel,
-  }) : _color = null,
-       _size = _oudsCircularProgressIndicatorSize;
+  }) : _color = null;
 
   /// Creates an [OudsCircularProgressIndicator] with an explicit [color], bypassing the
   /// [status]-based color resolution.
@@ -142,22 +141,12 @@ class OudsCircularProgressIndicator extends OudsProgressIndicator {
     super.track = true,
     super.semanticLabel,
     Color? color,
-    double? size,
-  }) : _color = color,
-       _size = size;
+  }) : _color = color;
 
   /// Explicit color override used instead of resolving [OudsProgressIndicator.status].
   ///
   /// `null` when created via the public constructor, in which case [status] is used.
   final Color? _color;
-
-  /// Explicit diameter override (in pixels, before text-scale) used instead of
-  /// [_oudsCircularProgressIndicatorSize].
-  ///
-  /// `null` when created via the public constructor, in which case the default size is used.
-  /// The stroke width is scaled proportionally to this size so the indicator doesn't look
-  /// disproportionately thick when rendered smaller than the default size (e.g. inside a button).
-  final double? _size;
 
   @override
   State<OudsCircularProgressIndicator> createState() =>
@@ -172,8 +161,7 @@ class _OudsCircularProgressIndicatorState
     final statusModifier = OudsProgressIndicatorStatusModifier(context);
     final textScaler = MediaQuery.textScalerOf(context);
 
-    final indicatorSize = widget._size ?? _oudsCircularProgressIndicatorSize;
-    final defaultSize = textScaler.scale(indicatorSize);
+    final defaultSize = textScaler.scale(_oudsCircularProgressIndicatorSize);
     final progressValue = OudsProgressIndicatorUtils.clampedProgressValue(
       widget.progressType,
       widget.value,
@@ -181,7 +169,6 @@ class _OudsCircularProgressIndicatorState
     final indicatorColor =
         widget._color ?? statusModifier.getStatusColor(widget.status);
     final backgroundColor = styleModifier.getTrackColor(widget.track);
-    final strokeWidth = styleModifier.computeStrokeWidth(defaultSize);
     final gapSize = styleModifier.computeGapSize(widget.gapSize);
     final strokeCap = styleModifier.getStrokeCap(widget.gapSize);
 
@@ -215,7 +202,6 @@ class _OudsCircularProgressIndicatorState
             defaultSize: defaultSize,
             indicatorColor: indicatorColor,
             backgroundColor: backgroundColor,
-            strokeWidth: strokeWidth,
             gapSize: gapSize,
             strokeCap: strokeCap,
             reduceMotion: false,
@@ -234,7 +220,6 @@ class _OudsCircularProgressIndicatorState
       defaultSize: defaultSize,
       indicatorColor: indicatorColor,
       backgroundColor: backgroundColor,
-      strokeWidth: strokeWidth,
       gapSize: gapSize,
       strokeCap: strokeCap,
       reduceMotion: reduceMotionActivated,
@@ -257,7 +242,6 @@ class _OudsCircularProgressIndicatorState
     required double defaultSize,
     required Color indicatorColor,
     required Color backgroundColor,
-    required double strokeWidth,
     required double gapSize,
     required StrokeCap strokeCap,
     required bool reduceMotion,
@@ -269,44 +253,61 @@ class _OudsCircularProgressIndicatorState
 
     // SizedBox enforces the computed or custom size,
     // preventing parent constraints from altering the indicator dimensions.
-    return Transform.rotate(
-      angle: indeterminateWithReduceMotion ? 20 : 0,
-      child: indeterminateWithReduceMotion
-          ? Semantics(
-              label: semanticsLabel,
-              child: ExcludeSemantics(
-                child: CircularProgressIndicator(
-                  padding: EdgeInsets.zero,
-                  year2023: false,
-                  constraints: BoxConstraints(
-                    minWidth: defaultSize,
-                    minHeight: defaultSize,
+    return SizedBox(
+      width: defaultSize,
+      height: defaultSize,
+      child: Transform.rotate(
+        angle: indeterminateWithReduceMotion ? 20 : 0,
+        child: indeterminateWithReduceMotion
+            ? Semantics(
+                label: semanticsLabel,
+                child: ExcludeSemantics(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final strokeWidth = constraints.maxWidth * 0.125;
+
+                      return CircularProgressIndicator(
+                        padding: EdgeInsets.zero,
+                        year2023: false,
+                        constraints: BoxConstraints(
+                          minWidth: defaultSize,
+                          minHeight: defaultSize,
+                        ),
+                        value: 0.8,
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          indicatorColor,
+                        ),
+                        backgroundColor: backgroundColor,
+                        strokeWidth: strokeWidth,
+                        trackGap: gapSize,
+                        strokeCap: strokeCap,
+                      );
+                    },
                   ),
-                  value: 0.8,
-                  valueColor: AlwaysStoppedAnimation<Color>(indicatorColor),
-                  backgroundColor: backgroundColor,
-                  strokeWidth: strokeWidth,
-                  trackGap: gapSize,
-                  strokeCap: strokeCap,
                 ),
+              )
+            : LayoutBuilder(
+                builder: (context, constraints) {
+                  final strokeWidth = constraints.maxWidth * 0.125;
+                  return CircularProgressIndicator(
+                    padding: EdgeInsets.zero,
+                    semanticsLabel: semanticsLabel,
+                    semanticsValue: semanticsValue,
+                    year2023: false,
+                    constraints: BoxConstraints(
+                      minWidth: defaultSize,
+                      minHeight: defaultSize,
+                    ),
+                    value: value,
+                    valueColor: AlwaysStoppedAnimation<Color>(indicatorColor),
+                    backgroundColor: backgroundColor,
+                    trackGap: gapSize,
+                    strokeWidth: strokeWidth,
+                    strokeCap: strokeCap,
+                  );
+                },
               ),
-            )
-          : CircularProgressIndicator(
-              padding: EdgeInsets.zero,
-              semanticsLabel: semanticsLabel,
-              semanticsValue: semanticsValue,
-              year2023: false,
-              constraints: BoxConstraints(
-                minWidth: defaultSize,
-                minHeight: defaultSize,
-              ),
-              value: value,
-              valueColor: AlwaysStoppedAnimation<Color>(indicatorColor),
-              backgroundColor: backgroundColor,
-              strokeWidth: strokeWidth,
-              trackGap: gapSize,
-              strokeCap: strokeCap,
-            ),
+      ),
     );
   }
 }


### PR DESCRIPTION

_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

- #876 

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- NA My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/DEVELOP.md)
- NA I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- NA Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] CHANGELOG.md files have been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
