### PR TITLE
feat(button): update `button` to version 3.3.0 and add OudsButton.small

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.1.0...develop)
 ### Added
 ### Changed
+- [DemoApp][Library] For `button` component, update to version 3.3.0 ([#832](https://github.com/Orange-OpenSource/ouds-flutter/issues/832))
 ### Fixed
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.0.0...2.1.0) - 2026-08-07

--- a/app/lib/ui/components/button/button_code_generator.dart
+++ b/app/lib/ui/components/button/button_code_generator.dart
@@ -44,23 +44,23 @@ class ButtonCodeGenerator {
     String code = '';
 
     // Use the OudsButton.small constructor when the small size is selected, OudsButton otherwise
-    String constructorName = buttonConstructorName(context);
+    String buttonSizeConstructor = buttonVariant(context);
 
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsButtonLayout.textOnly:
         code =
-            """${coloredSurfaceCodeModifier(context)}$constructorName(\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+            """${coloredSurfaceCodeModifier(context)}$buttonSizeConstructor(\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconOnly:
         code =
-            """${coloredSurfaceCodeModifier(context)}$constructorName(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+            """${coloredSurfaceCodeModifier(context)}$buttonSizeConstructor(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconAndText:
         code =
-            """${coloredSurfaceCodeModifier(context)}$constructorName(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+            """${coloredSurfaceCodeModifier(context)}$buttonSizeConstructor(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
     }
 
@@ -103,12 +103,11 @@ class ButtonCodeGenerator {
 
   // Method to generate the constructor name based on the selected size:
   // `OudsButton.small` when small size is selected, `OudsButton` otherwise
-  static String buttonConstructorName(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
-      context,
-    );
+  static String buttonVariant(BuildContext context) {
+    final ButtonCustomizationState? customizationSizeState =
+        ButtonCustomization.of(context);
     OudsButtonSize size = ButtonCustomizationUtils.getSize(
-      customizationState?.selectedSize as Object,
+      customizationSizeState?.selectedSize as Object,
     );
     return size == OudsButtonSize.small ? "OudsButton.small" : "OudsButton";
   }

--- a/app/lib/ui/components/button/button_code_generator.dart
+++ b/app/lib/ui/components/button/button_code_generator.dart
@@ -26,29 +26,41 @@ class ButtonCodeGenerator {
   // Static method to generate the code based on button customization state
   static String updateCode(BuildContext context) {
     // Fetch the current button customization state from context
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
 
     // Get the text value for the button from customization state
     String label = customizationState?.textValue ?? "Button";
 
     // Get the button's appearance, style, and layout from customization state
-    OudsButtonAppearance appearance = ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object);
-    OudsButtonLayout layout = ButtonCustomizationUtils.getLayout(customizationState?.selectedLayout as Object);
+    OudsButtonAppearance appearance = ButtonCustomizationUtils.getAppearance(
+      customizationState?.selectedAppearance as Object,
+    );
+    OudsButtonLayout layout = ButtonCustomizationUtils.getLayout(
+      customizationState?.selectedLayout as Object,
+    );
 
     String code = '';
+
+    // Use the OudsButton.small constructor when the small size is selected, OudsButton otherwise
+    String constructorName = buttonConstructorName(context);
 
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsButtonLayout.textOnly:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code =
+            """${coloredSurfaceCodeModifier(context)}$constructorName(\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconOnly:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code =
+            """${coloredSurfaceCodeModifier(context)}$constructorName(\nicon: 'assets/ic_heart.svg',\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
 
       case OudsButtonLayout.iconAndText:
-        code = """${coloredSurfaceCodeModifier(context)}OudsButton(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
+        code =
+            """${coloredSurfaceCodeModifier(context)}$constructorName(\nicon: 'assets/ic_heart.svg',\nlabel: "$label",\nappearance: ${appearance.toString()},${fullWidthCodeModifier(context)}${loaderCodeModifier(context)}\n${disableCode(context)}""";
         break;
     }
 
@@ -57,7 +69,9 @@ class ButtonCodeGenerator {
 
   // Method to generate the disable code for the button's onPressed callback
   static String disableCode(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
 
     String end = customizationState?.hasOnColoredBox == true ? " ),\n);" : ");";
 
@@ -66,7 +80,9 @@ class ButtonCodeGenerator {
   }
 
   static String loaderCodeModifier(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
     if (customizationState?.hasLoader == true) {
       return "\nloader: Loader(progress: null),";
     } else {
@@ -75,7 +91,9 @@ class ButtonCodeGenerator {
   }
 
   static String fullWidthCodeModifier(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
     if (customizationState?.hasFullWidth == true) {
       return "\nisFullWidth: ${customizationState?.hasFullWidth},";
     } else {
@@ -83,15 +101,30 @@ class ButtonCodeGenerator {
     }
   }
 
+  // Method to generate the constructor name based on the selected size:
+  // `OudsButton.small` when small size is selected, `OudsButton` otherwise
+  static String buttonConstructorName(BuildContext context) {
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
+    OudsButtonSize size = ButtonCustomizationUtils.getSize(
+      customizationState?.selectedSize as Object,
+    );
+    return size == OudsButtonSize.small ? "OudsButton.small" : "OudsButton";
+  }
+
   // Method to generate code for a colored surface wrapper around the button, if needed
   static String coloredSurfaceCodeModifier(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
 
     String code = '';
 
     // If the button should have a colored surface, wrap the button in OudsColoredBox
     if (customizationState?.hasOnColoredBox == true) {
-      code = '''OudsColoredBox(\ncolor: OudsColoredBoxColor.brandPrimary,\nchild: ''';
+      code =
+          '''OudsColoredBox(\ncolor: OudsColoredBoxColor.brandPrimary,\nchild: ''';
     }
 
     return code;

--- a/app/lib/ui/components/button/button_code_generator.dart
+++ b/app/lib/ui/components/button/button_code_generator.dart
@@ -84,7 +84,7 @@ class ButtonCodeGenerator {
       context,
     );
     if (customizationState?.hasLoader == true) {
-      return "\nloader: Loader(progress: null),";
+      return "\nisLoading: true,";
     } else {
       return "";
     }

--- a/app/lib/ui/components/button/button_customization.dart
+++ b/app/lib/ui/components/button/button_customization.dart
@@ -36,6 +36,7 @@ class ButtonCustomizationState
   late final FullWidthState fullWidthState;
   late final ChevronState chevronState;
   late final NavigationAppearanceState navigationAppearanceState;
+  late final SizeState sizeState;
 
   @override
   void initState() {
@@ -49,6 +50,7 @@ class ButtonCustomizationState
       setState,
       onColoredBoxState,
     );
+    sizeState = SizeState(setState);
   }
 
   // Getter to determine if the 'OnColoredBox' should be disabled
@@ -86,6 +88,9 @@ class ButtonCustomizationState
       navigationAppearanceState.selected;
   set selectedNavigationAppearance(NavigationButtonEnumAppearance value) =>
       navigationAppearanceState.selected = value;
+
+  ButtonEnumSize get selectedSize => sizeState.selected;
+  set selectedSize(ButtonEnumSize value) => sizeState.selected = value;
 
   @override
   Widget build(BuildContext context) {
@@ -256,6 +261,33 @@ class NavigationAppearanceState {
       if (ButtonErrorCases.shouldDisableOnColoredBox(newValue)) {
         onColoredBoxState.value = false;
       }
+    });
+  }
+}
+
+/// Size State Management
+class SizeState {
+  SizeState(this._setState);
+
+  final void Function(void Function()) _setState;
+
+  List<ButtonEnumSize> _sizeList = [
+    ButtonEnumSize.defaultSize,
+    ButtonEnumSize.small,
+  ];
+  ButtonEnumSize _selectedSize = ButtonEnumSize.defaultSize;
+
+  List<ButtonEnumSize> get list => _sizeList;
+  set list(List<ButtonEnumSize> newList) {
+    _setState(() {
+      _sizeList = newList;
+    });
+  }
+
+  ButtonEnumSize get selected => _selectedSize;
+  set selected(ButtonEnumSize newValue) {
+    _setState(() {
+      _selectedSize = newValue;
     });
   }
 }

--- a/app/lib/ui/components/button/button_customization_utils.dart
+++ b/app/lib/ui/components/button/button_customization_utils.dart
@@ -50,6 +50,16 @@ class ButtonCustomizationUtils {
     return null;
   }
 
+  /// Maps the size enum to `OudsButtonSize`.
+  static OudsButtonSize getSize(Object size) {
+    switch (size) {
+      case ButtonEnumSize.small:
+        return OudsButtonSize.small;
+      default:
+        return OudsButtonSize.defaultSize;
+    }
+  }
+
   /// Maps the layout enum to `OudsButtonLayout`.
   static OudsButtonLayout getLayout(Object layout) {
     switch (layout) {

--- a/app/lib/ui/components/button/button_customization_utils.dart
+++ b/app/lib/ui/components/button/button_customization_utils.dart
@@ -43,9 +43,9 @@ class ButtonCustomizationUtils {
   }
 
   /// Displays the loader if it is selected .
-  static Loader? getLoader(ButtonCustomizationState? customizationState) {
+  static bool? getLoader(ButtonCustomizationState? customizationState) {
     if (customizationState?.hasLoader == true) {
-      return Loader(progress: null);
+      return true;
     }
     return null;
   }

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -37,7 +37,7 @@ import 'package:provider/provider.dart';
 /// This screen displays a button demo and allows customization of button properties
 class ButtonDemoScreen extends StatefulWidget {
   final String? previousPageTitle;
-  const ButtonDemoScreen({super.key,this.previousPageTitle});
+  const ButtonDemoScreen({super.key, this.previousPageTitle});
 
   @override
   State<ButtonDemoScreen> createState() => _ButtonDemoScreenState();
@@ -58,7 +58,11 @@ class _ButtonDemoScreenState extends State<ButtonDemoScreen> {
     return DismissKeyboard(
       child: ButtonCustomization(
         child: Padding(
-          padding: EdgeInsets.only(bottom: defaultTargetPlatform == TargetPlatform.android ? MediaQuery.of(context).viewPadding.bottom : OudsTheme.of(context).spaceScheme(context).paddingBlockNone),
+          padding: EdgeInsets.only(
+            bottom: defaultTargetPlatform == TargetPlatform.android
+                ? MediaQuery.of(context).viewPadding.bottom
+                : OudsTheme.of(context).spaceScheme(context).paddingBlockNone,
+          ),
           child: Scaffold(
             bottomSheet: OudsSheetsBottom(
               onExpansionChanged: _onExpansionChanged,
@@ -70,7 +74,8 @@ class _ButtonDemoScreenState extends State<ButtonDemoScreen> {
             appBar: MainAppBar(
               title: context.l10n.app_components_button_label,
               showBackButton: true,
-                previousPageTitle: widget.previousPageTitle),
+              previousPageTitle: widget.previousPageTitle,
+            ),
             body: ExcludeSemantics(
               excluding: !_isBottomSheetExpanded,
               child: _Body(),
@@ -91,19 +96,22 @@ class _Body extends StatefulWidget {
 class _BodyState extends State<_Body> {
   @override
   Widget build(BuildContext context) {
-    ThemeController? themeController = Provider.of<ThemeController>(context, listen: false);
+    ThemeController? themeController = Provider.of<ThemeController>(
+      context,
+      listen: false,
+    );
     return DetailScreenDescription(
       description: context.l10n.app_components_button_description_text,
       widget: Column(
         children: [
           _ButtonDemo(),
-          SizedBox(height: themeController.currentTheme.spaceScheme(context).fixedMedium),
-          Code(
-            code: ButtonCodeGenerator.updateCode(context),
+          SizedBox(
+            height: themeController.currentTheme
+                .spaceScheme(context)
+                .fixedMedium,
           ),
-          ReferenceDesignVersionComponent(
-            version: OudsComponentVersion.button,
-          )
+          Code(code: ButtonCodeGenerator.updateCode(context)),
+          ReferenceDesignVersionComponent(version: OudsComponentVersion.button),
         ],
       ),
     );
@@ -120,6 +128,43 @@ class _ButtonDemoState extends State<_ButtonDemo> {
   ButtonCustomizationState? customizationState;
   ThemeController? themeController;
 
+  /// Builds the demo [OudsButton], using the [OudsButton.small] constructor when the
+  /// small size is selected, and the default [OudsButton] constructor otherwise.
+  Widget _buildButton() {
+    final size = ButtonCustomizationUtils.getSize(
+      customizationState?.selectedSize as Object,
+    );
+    final label = ButtonCustomizationUtils.getText(customizationState);
+    final icon = ButtonCustomizationUtils.getIcon(
+      customizationState,
+      themeController!,
+    );
+    final appearance = ButtonCustomizationUtils.getAppearance(
+      customizationState?.selectedAppearance as Object,
+    );
+    final loader = ButtonCustomizationUtils.getLoader(customizationState);
+    final onPressed = customizationState?.hasEnabled == true ? () {} : null;
+    final isFullWidth = customizationState?.hasFullWidth;
+
+    return size == OudsButtonSize.small
+        ? OudsButton.small(
+            label: label,
+            icon: icon,
+            appearance: appearance,
+            loader: loader,
+            onPressed: onPressed,
+            isFullWidth: isFullWidth,
+          )
+        : OudsButton(
+            label: label,
+            icon: icon,
+            appearance: appearance,
+            loader: loader,
+            onPressed: onPressed,
+            isFullWidth: isFullWidth,
+          );
+  }
+
   @override
   Widget build(BuildContext context) {
     customizationState = ButtonCustomization.of(context);
@@ -133,26 +178,10 @@ class _ButtonDemoState extends State<_ButtonDemo> {
     if (customizationState?.hasOnColoredBox == true) {
       return ComponentDemoBox(
         colored: customizationState?.hasOnColoredBox == true,
-        child: OudsButton(
-          label: ButtonCustomizationUtils.getText(customizationState),
-          icon: ButtonCustomizationUtils.getIcon(customizationState, themeController!),
-          appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
-          loader: ButtonCustomizationUtils.getLoader(customizationState),
-          onPressed: customizationState?.hasEnabled == true ? () {} : null,
-          isFullWidth: customizationState?.hasFullWidth,
-        ),
+        child: _buildButton(),
       );
     } else {
-      return LightDarkBox(
-        child: OudsButton(
-          label: ButtonCustomizationUtils.getText(customizationState),
-          icon: ButtonCustomizationUtils.getIcon(customizationState, themeController!),
-          appearance: ButtonCustomizationUtils.getAppearance(customizationState?.selectedAppearance as Object),
-          loader: ButtonCustomizationUtils.getLoader(customizationState),
-          onPressed: customizationState?.hasEnabled == true ? () {} : null,
-          isFullWidth: customizationState?.hasFullWidth,
-        ),
-      );
+      return LightDarkBox(child: _buildButton());
     }
   }
 }
@@ -183,8 +212,10 @@ class _CustomizationContentState extends State<_CustomizationContent> {
 
   @override
   Widget build(BuildContext context) {
-    final ButtonCustomizationState? customizationState = ButtonCustomization.of(context);
-    if(customizationState == null) return SizedBox.shrink();
+    final ButtonCustomizationState? customizationState = ButtonCustomization.of(
+      context,
+    );
+    if (customizationState == null) return SizedBox.shrink();
 
     return CustomizableSection(
       children: [
@@ -192,13 +223,12 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           title: context.l10n.app_common_enabled_label,
           value: customizationState.hasEnabled,
           onChanged:
-
               /// Specific case: Enabled disabled if style is 'Loading'
               customizationState.isEnabledWhenLoading == true
-                  ? null
-                  : (value) {
-                      customizationState.hasEnabled = value;
-                    },
+              ? null
+              : (value) {
+                  customizationState.hasEnabled = value;
+                },
         ),
         CustomizableSwitch(
           title: context.l10n.app_components_button_fullWidth_label,
@@ -211,13 +241,12 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           title: context.l10n.app_components_common_onColoredBackground_label,
           value: customizationState.hasOnColoredBox,
           onChanged:
-
               /// Specific case: OnColoredBox disabled if appearance is 'Negative'
               customizationState.isOnColoredBoxDisabled == true
-                  ? null
-                  : (value) {
-                      customizationState.hasOnColoredBox = value;
-                    },
+              ? null
+              : (value) {
+                  customizationState.hasOnColoredBox = value;
+                },
         ),
         CustomizableChips<ButtonEnumAppearance>(
           title: ButtonEnumAppearance.enumName(context),
@@ -227,6 +256,17 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           onSelected: (selectedOption) {
             setState(() {
               customizationState.selectedAppearance = selectedOption;
+            });
+          },
+        ),
+        CustomizableChips<ButtonEnumSize>(
+          title: ButtonEnumSize.enumName(context),
+          options: customizationState.sizeState.list,
+          selectedOption: customizationState.selectedSize,
+          getText: (option) => option.stringValue(context),
+          onSelected: (selectedOption) {
+            setState(() {
+              customizationState.selectedSize = selectedOption;
             });
           },
         ),
@@ -253,7 +293,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           text: customizationState.textValue,
           focusNode: labelFocus,
           fieldType: FieldType.label,
-        )
+        ),
       ],
     );
   }

--- a/app/lib/ui/components/button/button_demo_screen.dart
+++ b/app/lib/ui/components/button/button_demo_screen.dart
@@ -151,7 +151,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             label: label,
             icon: icon,
             appearance: appearance,
-            loader: loader,
+            isLoading: loader,
             onPressed: onPressed,
             isFullWidth: isFullWidth,
           )
@@ -159,7 +159,7 @@ class _ButtonDemoState extends State<_ButtonDemo> {
             label: label,
             icon: icon,
             appearance: appearance,
-            loader: loader,
+            isLoading: loader,
             onPressed: onPressed,
             isFullWidth: isFullWidth,
           );

--- a/app/lib/ui/components/button/button_enum.dart
+++ b/app/lib/ui/components/button/button_enum.dart
@@ -72,6 +72,27 @@ extension CustomElementLayout on ButtonEnumLayout {
   }
 }
 
+/// Represents the size of an OUDS button.
+enum ButtonEnumSize {
+  defaultSize,
+  small;
+
+  static String enumName(BuildContext context) {
+    return context.l10n.app_components_common_size_label;
+  }
+}
+
+extension CustomElementButtonSize on ButtonEnumSize {
+  String stringValue(BuildContext context) {
+    switch (this) {
+      case ButtonEnumSize.defaultSize:
+        return capitalizeEnumValue(ButtonEnumSize.defaultSize);
+      case ButtonEnumSize.small:
+        return capitalizeEnumValue(ButtonEnumSize.small);
+    }
+  }
+}
+
 /// Represents the size of an OUDS Navigation Button.
 enum NavigationButtonLayoutEnum {
   next,

--- a/app/lib/ui/components/button/navigation_button_demo_screen.dart
+++ b/app/lib/ui/components/button/navigation_button_demo_screen.dart
@@ -155,7 +155,7 @@ class _NavigationButtonDemoState extends State<_NavigationButtonDemo> {
             customizationState!.selectedNavigationAppearance,
           ),
           package: OudsTheme.of(context).packageName,
-          loader: ButtonCustomizationUtils.getLoader(customizationState),
+          isLoading: ButtonCustomizationUtils.getLoader(customizationState),
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
           isFullWidth: customizationState?.hasFullWidth,
           semanticsLabel: ButtonCustomizationUtils.getSemanticsLabel(
@@ -177,7 +177,7 @@ class _NavigationButtonDemoState extends State<_NavigationButtonDemo> {
             customizationState!.selectedNavigationAppearance,
           ),
           package: OudsTheme.of(context).packageName,
-          loader: ButtonCustomizationUtils.getLoader(customizationState),
+          isLoading: ButtonCustomizationUtils.getLoader(customizationState),
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
           isFullWidth: customizationState?.hasFullWidth,
           semanticsLabel: ButtonCustomizationUtils.getSemanticsLabel(

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.1.0...develop)
 ### Added
 ### Changed
+- [Library] For `button` component, update to version 3.3.0 ([#832](https://github.com/Orange-OpenSource/ouds-flutter/issues/832))
 ### Fixed
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-flutter/compare/2.0.0...2.1.0) - 2026-08-07

--- a/ouds_core/README.md
+++ b/ouds_core/README.md
@@ -84,7 +84,7 @@ It is intended to replace internal frameworks and the previous [ODS](https://git
     </tr>
     <tr>
       <td style="padding-left:10px;">Button</td>
-      <td>3.2.0</td>
+      <td>3.3.0</td>
     </tr>
     <tr>
       <td style="padding:10px;">Checkbox</td>

--- a/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_background_modifier.dart
@@ -26,52 +26,71 @@ class OudsButtonBackgroundModifier {
     OudsButtonAppearance appearance,
     OudsButtonControlState? buttonState,
   ) {
-    return WidgetStateProperty.resolveWith<Color?>(
-      (Set<WidgetState> states) {
-        if (buttonState == OudsButtonControlState.loading) {
-          return OudsButtonLoadingModifier.getBackgroundToken(context, appearance);
-        }
+    return WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
+      if (buttonState == OudsButtonControlState.loading) {
+        return OudsButtonLoadingModifier.getBackgroundToken(
+          context,
+          appearance,
+        );
+      }
 
-        // Handles both Flutter's native pressed state and custom OudsButton state.
-        // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
-        if (states.contains(WidgetState.pressed) || (buttonState != null && buttonState == OudsButtonControlState.pressed)) {
-          return _getPressedColor(context, appearance);
-        } else if (states.contains(WidgetState.hovered)) {
-          return _getHoverColor(context, appearance);
-        } else if (states.contains(WidgetState.disabled)) {
-          return _getDisabledColor(context, appearance);
-        } else if (states.contains(WidgetState.focused) || (buttonState != null && buttonState == OudsButtonControlState.focused)) {
-          return _getFocusedColor(context, appearance);
-        }
+      // Handles both Flutter's native pressed state and custom OudsButton state.
+      // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
+      if (states.contains(WidgetState.pressed) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.pressed)) {
+        return _getPressedColor(context, appearance);
+      } else if (states.contains(WidgetState.hovered)) {
+        return _getHoverColor(context, appearance);
+      } else if (states.contains(WidgetState.disabled)) {
+        return _getDisabledColor(context, appearance);
+      } else if (states.contains(WidgetState.focused) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.focused)) {
+        return _getFocusedColor(context, appearance);
+      }
 
-        return _getEnabledColor(context, appearance);
-      },
-    );
+      return _getEnabledColor(context, appearance);
+    });
   }
 
-  static Color? _getFocusedColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? _getFocusedColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongFocus : theme.colorScheme(context).actionFocus;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongFocus
+            : theme.colorScheme(context).actionFocus;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorBgBrandFocus;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgMinimalFocus : theme.componentsTokens(context).button.colorBgMinimalFocus;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgMinimalFocus
+            : theme.componentsTokens(context).button.colorBgMinimalFocus;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionNegativeFocus;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultFocus : theme.componentsTokens(context).button.colorBgDefaultFocus;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultFocus
+            : theme.componentsTokens(context).button.colorBgDefaultFocus;
     }
   }
 
-  static Color? _getEnabledColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? _getEnabledColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongEnabled : theme.colorScheme(context).actionEnabled;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongEnabled
+            : theme.colorScheme(context).actionEnabled;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorBgBrandEnabled;
       case OudsButtonAppearance.minimal:
@@ -79,50 +98,75 @@ class OudsButtonBackgroundModifier {
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionNegativeEnabled;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultEnabled : theme.componentsTokens(context).button.colorBgDefaultEnabled;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultEnabled
+            : theme.componentsTokens(context).button.colorBgDefaultEnabled;
     }
   }
 
-  static Color? _getHoverColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? _getHoverColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongHover : theme.colorScheme(context).actionHover;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongHover
+            : theme.colorScheme(context).actionHover;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorBgBrandHover;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgMinimalHover : theme.componentsTokens(context).button.colorBgMinimalHover;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgMinimalHover
+            : theme.componentsTokens(context).button.colorBgMinimalHover;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionNegativeHover;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultHover : theme.componentsTokens(context).button.colorBgDefaultHover;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultHover
+            : theme.componentsTokens(context).button.colorBgDefaultHover;
     }
   }
 
-  static Color? _getPressedColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? _getPressedColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongPressed : theme.colorScheme(context).actionPressed;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongPressed
+            : theme.colorScheme(context).actionPressed;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorBgBrandPressed;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgMinimalPressed : theme.componentsTokens(context).button.colorBgMinimalPressed;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgMinimalPressed
+            : theme.componentsTokens(context).button.colorBgMinimalPressed;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionNegativePressed;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultPressed : theme.componentsTokens(context).button.colorBgDefaultPressed;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultPressed
+            : theme.componentsTokens(context).button.colorBgDefaultPressed;
     }
   }
 
-  static Color? _getDisabledColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? _getDisabledColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongDisabled : theme.colorScheme(context).actionDisabled;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongDisabled
+            : theme.colorScheme(context).actionDisabled;
       case OudsButtonAppearance.brand:
         return theme.colorScheme(context).actionDisabled;
       case OudsButtonAppearance.minimal:
@@ -130,7 +174,9 @@ class OudsButtonBackgroundModifier {
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionDisabled;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultDisabled : theme.componentsTokens(context).button.colorBgDefaultDisabled;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultDisabled
+            : theme.componentsTokens(context).button.colorBgDefaultDisabled;
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_border_modifier.dart
@@ -27,84 +27,140 @@ class OudsButtonBorderModifier {
     OudsButtonAppearance appearance,
     OudsButtonControlState? buttonState,
   ) {
-    return WidgetStateProperty.resolveWith<BorderSide?>(
-      (Set<WidgetState> states) {
-        if (buttonState == OudsButtonControlState.loading) {
-          return OudsButtonLoadingModifier.getBorderColor(context, appearance);
-        }
-        if (states.contains(WidgetState.pressed) || (buttonState != null && buttonState == OudsButtonControlState.pressed)) {
-          return _getPressedBorderColor(context, appearance);
-        } else if (states.contains(WidgetState.hovered)) {
-          return _getHoverBorderColor(context, appearance);
-        } else if (states.contains(WidgetState.disabled)) {
-          return _getDisabledBorderColor(context, appearance);
-        } else if (states.contains(WidgetState.focused) || (buttonState != null && buttonState == OudsButtonControlState.focused)) {
-          return _getFocusedBorderColor(context, appearance);
-        }
-        return _getEnabledBorderColor(context, appearance);
-      },
-    );
+    return WidgetStateProperty.resolveWith<BorderSide?>((
+      Set<WidgetState> states,
+    ) {
+      if (buttonState == OudsButtonControlState.loading) {
+        return OudsButtonLoadingModifier.getBorderColor(context, appearance);
+      }
+      if (states.contains(WidgetState.pressed) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.pressed)) {
+        return _getPressedBorderColor(context, appearance);
+      } else if (states.contains(WidgetState.hovered)) {
+        return _getHoverBorderColor(context, appearance);
+      } else if (states.contains(WidgetState.disabled)) {
+        return _getDisabledBorderColor(context, appearance);
+      } else if (states.contains(WidgetState.focused) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.focused)) {
+        return _getFocusedBorderColor(context, appearance);
+      }
+      return _getEnabledBorderColor(context, appearance);
+    });
   }
 
-  static BorderSide _getFocusedBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+  static BorderSide _getFocusedBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     if (appearance == OudsButtonAppearance.defaultAppearance) {
       return BorderSide(
-        color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultFocus : theme.componentsTokens(context).button.colorBorderDefaultFocus,
-        width: onColoredSurface ? theme.componentsTokens(context).button.borderWidthDefaultInteractionMono : theme.componentsTokens(context).button.borderWidthDefaultInteraction,
+        color: onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBorderDefaultFocus
+            : theme.componentsTokens(context).button.colorBorderDefaultFocus,
+        width: onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .button
+                  .borderWidthDefaultInteractionMono
+            : theme
+                  .componentsTokens(context)
+                  .button
+                  .borderWidthDefaultInteraction,
       );
     } else {
       return BorderSide.none;
     }
   }
 
-  static BorderSide _getEnabledBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+  static BorderSide _getEnabledBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     if (appearance == OudsButtonAppearance.defaultAppearance) {
       return BorderSide(
-          color: onColoredSurface
-              ? theme.componentsTokens(context).buttonMono.colorBorderDefaultEnabled
-              : theme.componentsTokens(context).button.colorBorderDefaultEnabled,
-          width: theme.componentsTokens(context).button.borderWidthDefault);
-   } else {
-      return BorderSide.none;
-    }
-  }
-
-  static BorderSide _getHoverBorderColor(BuildContext context, OudsButtonAppearance appearance) {
-    final theme = OudsTheme.of(context);
-    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
-    if (appearance == OudsButtonAppearance.defaultAppearance) {
-      return BorderSide(
-          color: onColoredSurface
-              ? theme.componentsTokens(context).buttonMono.colorBorderDefaultEnabled
-              : theme.componentsTokens(context).button.colorBorderDefaultHover,
-          width: theme.componentsTokens(context).button.borderWidthDefaultInteraction);
+        color: onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorBorderDefaultEnabled
+            : theme.componentsTokens(context).button.colorBorderDefaultEnabled,
+        width: theme.componentsTokens(context).button.borderWidthDefault,
+      );
     } else {
       return BorderSide.none;
     }
   }
 
-  static BorderSide _getPressedBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+  static BorderSide _getHoverBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     if (appearance == OudsButtonAppearance.defaultAppearance) {
       return BorderSide(
-          color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultPressed : theme.componentsTokens(context).button.colorBorderDefaultPressed,
-          width: theme.componentsTokens(context).button.borderWidthDefaultInteraction);
+        color: onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorBorderDefaultEnabled
+            : theme.componentsTokens(context).button.colorBorderDefaultHover,
+        width: theme
+            .componentsTokens(context)
+            .button
+            .borderWidthDefaultInteraction,
+      );
     } else {
       return BorderSide.none;
     }
   }
 
-  static BorderSide _getDisabledBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+  static BorderSide _getPressedBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     if (appearance == OudsButtonAppearance.defaultAppearance) {
       return BorderSide(
-          color: onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBorderDefaultDisabled : theme.componentsTokens(context).button.colorBorderDefaultDisabled, width: theme.componentsTokens(context).button.borderWidthDefault);
+        color: onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorBorderDefaultPressed
+            : theme.componentsTokens(context).button.colorBorderDefaultPressed,
+        width: theme
+            .componentsTokens(context)
+            .button
+            .borderWidthDefaultInteraction,
+      );
+    } else {
+      return BorderSide.none;
+    }
+  }
+
+  static BorderSide _getDisabledBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
+    final theme = OudsTheme.of(context);
+    final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
+    if (appearance == OudsButtonAppearance.defaultAppearance) {
+      return BorderSide(
+        color: onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorBorderDefaultDisabled
+            : theme.componentsTokens(context).button.colorBorderDefaultDisabled,
+        width: theme.componentsTokens(context).button.borderWidthDefault,
+      );
     } else {
       return BorderSide.none;
     }
@@ -114,7 +170,8 @@ class OudsButtonBorderModifier {
   /// Returns a [BorderRadius] object with the appropriate radius value.
   static BorderRadius getBorderRadius(BuildContext context) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
-    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
+    final buttonRounded =
+        OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
     switch (buttonRounded) {
       case true:
         return BorderRadius.circular(button.borderRadiusRounded);
@@ -127,12 +184,16 @@ class OudsButtonBorderModifier {
   /// Returns a [BorderRadius] object with the appropriate radius value.
   static BorderRadius getBorderRadiusFocus(BuildContext context) {
     final button = OudsTheme.of(context).componentsTokens(context).button;
-    final buttonRounded = OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
+    final buttonRounded =
+        OudsThemeConfigModel.of(context)?.button?.rounded ?? false;
     switch (buttonRounded) {
       case true:
-        return BorderRadius.circular(button.borderRadiusRounded + (OudsTheme.of(context).borderTokens.widthFocus / 1.2));
+        return BorderRadius.circular(
+          button.borderRadiusRounded +
+              (OudsTheme.of(context).borderTokens.widthFocus / 1.2),
+        );
       case false:
-        return BorderRadius.circular(button.borderRadiusDefault ) ;
+        return BorderRadius.circular(button.borderRadiusDefault);
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_foreground_modifier.dart
@@ -26,110 +26,202 @@ class OudsButtonForegroundModifier {
     OudsButtonAppearance appearance,
     OudsButtonControlState? buttonState,
   ) {
-    return WidgetStateProperty.resolveWith<Color?>(
-      (Set<WidgetState> states) {
-        if (buttonState == OudsButtonControlState.loading) {
-          return OudsButtonLoadingModifier.getColorToken(context, appearance);
-        }
+    return WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
+      if (buttonState == OudsButtonControlState.loading) {
+        return OudsButtonLoadingModifier.getColorToken(context, appearance);
+      }
 
-        // Handles both Flutter's native pressed state and custom OudsButton state.
-        // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
-        if (states.contains(WidgetState.pressed) || (buttonState != null && buttonState == OudsButtonControlState.pressed)) {
-          return _getPressedForegroundColor(context, appearance);
-        } else if (states.contains(WidgetState.hovered)) {
-          return _getHoverForegroundColor(context, appearance);
-        } else if (states.contains(WidgetState.disabled)) {
-          return _getDisabledForegroundColor(context, appearance);
-        } else if (states.contains(WidgetState.focused) || (buttonState != null && buttonState == OudsButtonControlState.focused)) {
-          return _getFocusedForegroundColor(context, appearance);
-        }
-        return _getEnabledForegroundColor(context, appearance);
-      },
-    );
+      // Handles both Flutter's native pressed state and custom OudsButton state.
+      // `states` is the standard WidgetState set, while `buttonState` is a custom control enum.
+      if (states.contains(WidgetState.pressed) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.pressed)) {
+        return _getPressedForegroundColor(context, appearance);
+      } else if (states.contains(WidgetState.hovered)) {
+        return _getHoverForegroundColor(context, appearance);
+      } else if (states.contains(WidgetState.disabled)) {
+        return _getDisabledForegroundColor(context, appearance);
+      } else if (states.contains(WidgetState.focused) ||
+          (buttonState != null &&
+              buttonState == OudsButtonControlState.focused)) {
+        return _getFocusedForegroundColor(context, appearance);
+      }
+      return _getEnabledForegroundColor(context, appearance);
+    });
   }
 
-  static Color _getFocusedForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color _getFocusedForegroundColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongFocus : theme.colorScheme(context).contentOnActionFocus;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorContentStrongFocus
+            : theme.colorScheme(context).contentOnActionFocus;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorContentBrandFocus;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalFocus : theme.componentsTokens(context).button.colorContentMinimalFocus;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalFocus
+            : theme.componentsTokens(context).button.colorContentMinimalFocus;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultFocus : theme.componentsTokens(context).button.colorContentDefaultFocus;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultFocus
+            : theme.componentsTokens(context).button.colorContentDefaultFocus;
     }
   }
 
-  static Color _getEnabledForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color _getEnabledForegroundColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongEnabled : theme.colorScheme(context).contentOnActionEnabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentStrongEnabled
+            : theme.colorScheme(context).contentOnActionEnabled;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorContentBrandEnabled;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalEnabled : theme.componentsTokens(context).button.colorContentMinimalEnabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalEnabled
+            : theme.componentsTokens(context).button.colorContentMinimalEnabled;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultEnabled : theme.componentsTokens(context).button.colorContentDefaultEnabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultEnabled
+            : theme.componentsTokens(context).button.colorContentDefaultEnabled;
     }
   }
 
-  static Color _getHoverForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color _getHoverForegroundColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongHover : theme.colorScheme(context).contentOnActionHover;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorContentStrongHover
+            : theme.colorScheme(context).contentOnActionHover;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorContentBrandHover;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalHover : theme.componentsTokens(context).button.colorContentMinimalHover;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalHover
+            : theme.componentsTokens(context).button.colorContentMinimalHover;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultHover : theme.componentsTokens(context).button.colorContentDefaultHover;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultHover
+            : theme.componentsTokens(context).button.colorContentDefaultHover;
     }
   }
 
-  static Color _getPressedForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color _getPressedForegroundColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongPressed : theme.colorScheme(context).contentOnActionPressed;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentStrongPressed
+            : theme.colorScheme(context).contentOnActionPressed;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorContentBrandPressed;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalPressed : theme.componentsTokens(context).button.colorContentMinimalPressed;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalPressed
+            : theme.componentsTokens(context).button.colorContentMinimalPressed;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultPressed : theme.componentsTokens(context).button.colorContentDefaultPressed;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultPressed
+            : theme.componentsTokens(context).button.colorContentDefaultPressed;
     }
   }
 
-  static Color _getDisabledForegroundColor(BuildContext context, OudsButtonAppearance appearance) {
+  static Color _getDisabledForegroundColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongDisabled : theme.colorScheme(context).contentOnActionDisabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentStrongDisabled
+            : theme.colorScheme(context).contentOnActionDisabled;
       case OudsButtonAppearance.brand:
         return theme.colorScheme(context).contentOnActionDisabled;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalDisabled : theme.componentsTokens(context).button.colorContentMinimalDisabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalDisabled
+            : theme
+                  .componentsTokens(context)
+                  .button
+                  .colorContentMinimalDisabled;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnActionDisabled;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultDisabled : theme.componentsTokens(context).button.colorContentDefaultDisabled;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultDisabled
+            : theme
+                  .componentsTokens(context)
+                  .button
+                  .colorContentDefaultDisabled;
     }
   }
 }

--- a/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_icon_modifier.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_loading_modifier.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_utils.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
 /// Class responsible for modifying the icon appearance of an Ouds button based on its state and context.
@@ -230,14 +231,18 @@ class OudsButtonIconModifier {
     }
   }
 
-  /// Static method to get the icon size based on button layout.
-  static double getIconSize(BuildContext context, OudsButtonLayout layout) {
+  /// Static method to get the icon size based on button layout and size.
+  static double getIconSize(
+    BuildContext context,
+    OudsButtonLayout layout, {
+    OudsButtonSize size = OudsButtonSize.defaultSize,
+  }) {
     final buttonToken = OudsTheme.of(context).componentsTokens(context).button;
     switch (layout) {
       case OudsButtonLayout.iconOnly:
-        return buttonToken.sizeIconOnlyDefault;
+        return buttonToken.sizeIconOnly(size);
       case OudsButtonLayout.iconAndText:
-        return buttonToken.sizeIconDefault;
+        return buttonToken.sizeIcon(size);
       case OudsButtonLayout.textOnly:
         // TODO: Handle this case.
         throw UnimplementedError();

--- a/ouds_core/lib/components/button/internal/ouds_button_loading_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_loading_modifier.dart
@@ -28,29 +28,52 @@ class OudsButtonLoadingModifier {
     this.label,
   });
 
-  static Color getColorToken(BuildContext context, OudsButtonAppearance appearance) {
+  static Color getColorToken(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentStrongLoading : theme.colorScheme(context).contentOnActionLoading;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentStrongLoading
+            : theme.colorScheme(context).contentOnActionLoading;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorContentBrandLoading;
       case OudsButtonAppearance.minimal:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentMinimalLoading : theme.componentsTokens(context).button.colorContentMinimalLoading;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentMinimalLoading
+            : theme.componentsTokens(context).button.colorContentMinimalLoading;
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).contentOnStatusNegativeEmphasized;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorContentDefaultLoading : theme.colorScheme(context).actionLoading;
+        return onColoredSurface
+            ? theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorContentDefaultLoading
+            : theme.colorScheme(context).actionLoading;
     }
   }
 
-  static Color? getBackgroundToken(BuildContext context, OudsButtonAppearance appearance) {
+  static Color? getBackgroundToken(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     switch (appearance) {
       case OudsButtonAppearance.strong:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgStrongLoading : theme.colorScheme(context).actionLoading;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgStrongLoading
+            : theme.colorScheme(context).actionLoading;
       case OudsButtonAppearance.brand:
         return theme.componentsTokens(context).button.colorBgBrandLoading;
       case OudsButtonAppearance.minimal:
@@ -58,17 +81,40 @@ class OudsButtonLoadingModifier {
       case OudsButtonAppearance.negative:
         return theme.colorScheme(context).actionNegativeLoading;
       default:
-        return onColoredSurface ? theme.componentsTokens(context).buttonMono.colorBgDefaultLoading : theme.componentsTokens(context).button.colorBgDefaultLoading;
+        return onColoredSurface
+            ? theme.componentsTokens(context).buttonMono.colorBgDefaultLoading
+            : theme.componentsTokens(context).button.colorBgDefaultLoading;
     }
   }
 
-  static BorderSide getBorderColor(BuildContext context, OudsButtonAppearance appearance) {
+  static BorderSide getBorderColor(
+    BuildContext context,
+    OudsButtonAppearance appearance,
+  ) {
     final theme = OudsTheme.of(context);
     final onColoredSurface = OudsTheme.isOnColoredSurfaceOf(context);
     if (appearance == OudsButtonAppearance.defaultAppearance) {
       return onColoredSurface
-          ? BorderSide(color: theme.componentsTokens(context).buttonMono.colorBorderDefaultLoading, width: theme.componentsTokens(context).button.borderWidthDefaultInteraction)
-          : BorderSide(color: theme.componentsTokens(context).button.colorBorderDefaultLoading, width: theme.componentsTokens(context).button.borderWidthDefaultInteraction);
+          ? BorderSide(
+              color: theme
+                  .componentsTokens(context)
+                  .buttonMono
+                  .colorBorderDefaultLoading,
+              width: theme
+                  .componentsTokens(context)
+                  .button
+                  .borderWidthDefaultInteraction,
+            )
+          : BorderSide(
+              color: theme
+                  .componentsTokens(context)
+                  .button
+                  .colorBorderDefaultLoading,
+              width: theme
+                  .componentsTokens(context)
+                  .button
+                  .borderWidthDefaultInteraction,
+            );
     } else {
       return BorderSide.none;
     }

--- a/ouds_core/lib/components/button/internal/ouds_button_padding_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_padding_modifier.dart
@@ -14,6 +14,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_utils.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
@@ -22,8 +23,9 @@ class OudsButtonPaddingModifier {
     BuildContext context,
     OudsButtonLayout layout,
     OudsNavigationButtonLayout? navigationLayout,
-    OudsButtonComponent componentType,
-  ) {
+    OudsButtonComponent componentType, {
+    OudsButtonSize size = OudsButtonSize.defaultSize,
+  }) {
     final buttonTokens = OudsTheme.of(context).componentsTokens(context).button;
     final isNavigationButton =
         componentType == OudsButtonComponent.navigationButton;
@@ -35,30 +37,28 @@ class OudsButtonPaddingModifier {
         navigationLayout == OudsNavigationButtonLayout.previous;
     switch (layout) {
       case OudsButtonLayout.iconOnly:
-        return EdgeInsetsDirectional.all(
-          buttonTokens.spaceInsetIconOnlyDefault,
-        );
+        return EdgeInsetsDirectional.all(buttonTokens.spaceInsetIconOnly(size));
       case OudsButtonLayout.iconAndText:
         return EdgeInsetsDirectional.only(
-          top: buttonTokens.spacePaddingBlockDefault,
+          top: buttonTokens.spacePaddingBlock(size),
           end:
               isNextLayout //case navigation button with next layout
-              ? buttonTokens.spacePaddingInlineChevronEndDefault
+              ? buttonTokens.spacePaddingInlineChevronEnd(size)
               : //case navigation button with previous layout or normal button
-                buttonTokens.spacePaddingInlineEndIconStartDefault,
-          bottom: buttonTokens.spacePaddingBlockDefault,
+                buttonTokens.spacePaddingInlineEndIconStart(size),
+          bottom: buttonTokens.spacePaddingBlock(size),
           start:
               isNextLayout // case navigation button with next layout
-              ? buttonTokens.spacePaddingInlineStartIconEndDefault
+              ? buttonTokens.spacePaddingInlineStartIconEnd(size)
               : isPreviousLayout // case navigation button with previous layout
-              ? buttonTokens.spacePaddingInlineChevronStartDefault
+              ? buttonTokens.spacePaddingInlineChevronStart(size)
               : //normal button
-                buttonTokens.spacePaddingInlineIconStartDefault,
+                buttonTokens.spacePaddingInlineIconStart(size),
         );
       case OudsButtonLayout.textOnly:
         return EdgeInsetsDirectional.symmetric(
-          vertical: buttonTokens.spacePaddingBlockDefault,
-          horizontal: buttonTokens.spacePaddingInlineIconNoneDefault,
+          vertical: buttonTokens.spacePaddingBlock(size),
+          horizontal: buttonTokens.spacePaddingInlineIconNone(size),
         );
     }
   }

--- a/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_style_modifier.dart
@@ -19,6 +19,7 @@ import 'package:ouds_core/components/button/internal/ouds_button_border_modifier
 import 'package:ouds_core/components/button/internal/ouds_button_control_state.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_foreground_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_padding_modifier.dart';
+import 'package:ouds_core/components/button/internal/ouds_button_utils.dart';
 import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 
@@ -30,7 +31,9 @@ class OudsButtonStyleModifier {
     OudsButtonControlState? buttonState,
     OudsNavigationButtonLayout? navigationLayout,
     OudsButtonComponent componentType = OudsButtonComponent.defaultButton,
+    OudsButtonSize size = OudsButtonSize.defaultSize,
   }) {
+    final buttonTokens = OudsTheme.of(context).componentsTokens(context).button;
     return ButtonStyle(
       backgroundColor: OudsButtonBackgroundModifier.resolveBackgroundColor(
         context,
@@ -60,17 +63,11 @@ class OudsButtonStyleModifier {
           layout,
           navigationLayout,
           componentType,
+          size: size,
         ),
       ),
       minimumSize: WidgetStateProperty.all<Size>(
-        Size(
-          OudsTheme.of(
-            context,
-          ).componentsTokens(context).button.sizeMinWidthDefault,
-          OudsTheme.of(
-            context,
-          ).componentsTokens(context).button.sizeMinHeightDefault,
-        ),
+        Size(buttonTokens.sizeMinWidth(size), buttonTokens.sizeMinHeight(size)),
       ),
       tapTargetSize: MaterialTapTargetSize
           .shrinkWrap, // this added to eliminate the white space between container and outlined button in orange compact in focus state

--- a/ouds_core/lib/components/button/internal/ouds_button_utils.dart
+++ b/ouds_core/lib/components/button/internal/ouds_button_utils.dart
@@ -23,6 +23,7 @@ import 'package:ouds_core/components/button/ouds_button.dart';
 import 'package:ouds_core/components/common/ouds_icon_status.dart';
 import 'package:ouds_core/components/top_bar/ouds_top_bar.dart';
 import 'package:ouds_core/components/utilities/badge_border_utils.dart';
+import 'package:ouds_theme_contract/theme/tokens/components/ouds_button_tokens.dart';
 
 /// Builds an icon button with optional badge, wrapped with semantics for accessibility.
 ///
@@ -123,4 +124,78 @@ String getDefaultChevronIcon(OudsNavigationButtonLayout layout) {
     case OudsNavigationButtonLayout.previous:
       return 'assets/component/button/previous.svg';
   }
+}
+
+/// Resolves the [OudsButtonTokens] size-dependent values (min size, paddings, icon size, …)
+/// based on the given [OudsButtonSize], since Tokenator generates a `Default` and a `Small`
+/// variant for each of these tokens.
+extension OudsButtonSizeTokens on OudsButtonTokens {
+  double sizeMinWidth(OudsButtonSize size) =>
+      size == OudsButtonSize.small ? sizeMinWidthSmall : sizeMinWidthDefault;
+
+  double sizeMinHeight(OudsButtonSize size) =>
+      size == OudsButtonSize.small ? sizeMinHeightSmall : sizeMinHeightDefault;
+
+  double sizeIcon(OudsButtonSize size) =>
+      size == OudsButtonSize.small ? sizeIconSmall : sizeIconDefault;
+
+  double sizeIconOnly(OudsButtonSize size) =>
+      size == OudsButtonSize.small ? sizeIconOnlySmall : sizeIconOnlyDefault;
+
+  double sizeProgressIndicator(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? sizeProgressIndicatorSmall
+      : sizeProgressIndicatorDefault;
+
+  double spaceProgressIndicator(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spaceInsetProgressIndicatorOnlySmall
+      : spaceInsetProgressIndicatorOnlyDefault;
+
+  double spaceColumnGapIcon(OudsButtonSize size) => size == OudsButtonSize.small
+      ? spaceColumnGapIconSmall
+      : spaceColumnGapIconDefault;
+
+  double spaceColumnGapChevron(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spaceColumnGapChevronSmall
+      : spaceColumnGapChevronDefault;
+
+  double spaceInsetIconOnly(OudsButtonSize size) => size == OudsButtonSize.small
+      ? spaceInsetIconOnlySmall
+      : spaceInsetIconOnlyDefault;
+
+  double spacePaddingBlock(OudsButtonSize size) => size == OudsButtonSize.small
+      ? spacePaddingBlockSmall
+      : spacePaddingBlockDefault;
+
+  double spacePaddingInlineChevronEnd(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineChevronEndSmall
+      : spacePaddingInlineChevronEndDefault;
+
+  double spacePaddingInlineChevronStart(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineChevronStartSmall
+      : spacePaddingInlineChevronStartDefault;
+
+  double spacePaddingInlineEndIconStart(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineEndIconStartSmall
+      : spacePaddingInlineEndIconStartDefault;
+
+  double spacePaddingInlineIconNone(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineIconNoneSmall
+      : spacePaddingInlineIconNoneDefault;
+
+  double spacePaddingInlineIconStart(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineIconStartSmall
+      : spacePaddingInlineIconStartDefault;
+
+  double spacePaddingInlineStartIconEnd(OudsButtonSize size) =>
+      size == OudsButtonSize.small
+      ? spacePaddingInlineStartIconEndSmall
+      : spacePaddingInlineStartIconEndDefault;
 }

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -118,12 +118,11 @@ enum OudsButtonComponent {
 ///   `icons/heart.svg` .
 /// - [isFullWidth]: Flag to let button take all the screen width, set to *false* by default.
 ///
-/// ### You can use [OudsButton] component in your project, customizing parameters as needed :
+/// ## Usage example :
 ///
-/// **Text only button :**
+/// ### Text only button :
 ///
 /// This is the default layout of the component.
-///
 ///
 /// ```dart
 /// OudsButton(
@@ -150,6 +149,17 @@ enum OudsButtonComponent {
 ///     );
 /// ```
 ///
+/// ### Small text only button :
+///
+/// ```dart
+/// OudsButton.small(
+///       label: 'Button',
+///       appearance: OudsButtonAppearance.defaultAppearance,
+///       onPressed: () {
+///         // Handle button tap.
+///      },
+///     );
+/// ```
 ///
 class OudsButton extends StatefulWidget {
   final String? label;
@@ -191,7 +201,8 @@ class OudsButton extends StatefulWidget {
 
   /// Creates an [OudsButton] with [OudsButtonSize.small], for contexts where space is constrained.
   ///
-  /// This is a convenience constructor equivalent to `OudsButton(size: OudsButtonSize.small, ...)`.
+  /// This size can be particularly useful in an information-dense interface or in the construction of a template or component requiring the use of small elements (in a "List item" component, for example).
+  /// The default size is available via [OudsButton].
   ///
   /// ```dart
   /// OudsButton.small(

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -66,6 +66,17 @@ enum OudsButtonLayout { textOnly, iconAndText, iconOnly }
 ///
 /// A private enum to use only into the lib
 ///
+/// Defines the size of an [OudsButton].
+///
+/// Use this enum to control the overall dimensions (min size, paddings, icon size, …) of a button:
+/// - [defaultSize]: standard size, suitable for most use cases.
+/// - [small]: compact size, used when space is constrained.
+enum OudsButtonSize { defaultSize, small }
+
+///@nodoc
+///
+/// A private enum to use only into the lib
+///
 /// Defines the type of button component.
 ///
 /// Use this enum to distinguish between a standard [OudsButton] and an [OudsNavigationButton]:
@@ -148,6 +159,12 @@ class OudsButton extends StatefulWidget {
   final OudsButtonAppearance appearance;
   final String? package;
   final bool? isFullWidth;
+
+  /// The button size based on its [OudsButtonSize], set to [OudsButtonSize.defaultSize] by default.
+  final OudsButtonSize _size;
+
+  /// Distinguishes a standard button from an [OudsNavigationButton], since both are
+  /// backed by this same widget internally.
   final OudsButtonComponent _component;
 
   /// Navigation layout used internally by [OudsNavigationButton].
@@ -167,7 +184,35 @@ class OudsButton extends StatefulWidget {
     required this.appearance,
     this.package,
     this.isFullWidth = false,
-  }) : _component = OudsButtonComponent.defaultButton,
+  }) : _size = OudsButtonSize.defaultSize,
+       _component = OudsButtonComponent.defaultButton,
+       _navigationLayout = null,
+       _semanticsLabel = null;
+
+  /// Creates an [OudsButton] with [OudsButtonSize.small], for contexts where space is constrained.
+  ///
+  /// This is a convenience constructor equivalent to `OudsButton(size: OudsButtonSize.small, ...)`.
+  ///
+  /// ```dart
+  /// OudsButton.small(
+  ///       label: 'Button',
+  ///       appearance: OudsButtonAppearance.defaultAppearance,
+  ///       onPressed: () {
+  ///         // Handle button tap.
+  ///      },
+  ///     );
+  /// ```
+  const OudsButton.small({
+    super.key,
+    this.label,
+    this.icon,
+    this.onPressed,
+    this.loader,
+    required this.appearance,
+    this.package,
+    this.isFullWidth = false,
+  }) : _size = OudsButtonSize.small,
+       _component = OudsButtonComponent.defaultButton,
        _navigationLayout = null,
        _semanticsLabel = null;
 
@@ -181,10 +226,12 @@ class OudsButton extends StatefulWidget {
     required this.appearance,
     this.package,
     this.isFullWidth = false,
+    OudsButtonSize size = OudsButtonSize.defaultSize,
     this.loader,
     required OudsNavigationButtonLayout navigationLayout,
     String? semanticsLabel,
-  }) : _component = OudsButtonComponent.navigationButton,
+  }) : _size = size,
+       _component = OudsButtonComponent.navigationButton,
        _navigationLayout = navigationLayout,
        _semanticsLabel = semanticsLabel;
 
@@ -377,6 +424,15 @@ class _OudsButtonState extends State<OudsButton> {
         : _buildLayout(context, buttonState);
   }
 
+  /// Returns the label typography based on [widget._size]: [OudsButtonSize.defaultSize]
+  /// uses the large strong label style, [OudsButtonSize.small] uses the medium one.
+  TextStyle _labelTypography(BuildContext context) {
+    final typography = OudsTheme.of(context).typographyTokens;
+    return widget._size == OudsButtonSize.small
+        ? typography.typeLabelStrongMedium(context)
+        : typography.typeLabelStrongLarge(context);
+  }
+
   /// Dispatches to the appropriate layout builder based on [widget.layout].
   Widget _buildLayout(
     BuildContext context,
@@ -390,8 +446,8 @@ class _OudsButtonState extends State<OudsButton> {
       case OudsButtonLayout.iconAndText:
         return Container(
           constraints: BoxConstraints(
-            minWidth: buttonToken.sizeMinWidthDefault,
-            minHeight: buttonToken.sizeMinHeightDefault,
+            minWidth: buttonToken.sizeMinWidth(widget._size),
+            minHeight: buttonToken.sizeMinHeight(widget._size),
           ),
           child: widget._component == OudsButtonComponent.navigationButton
               ? _buildNavigationButton(context, buttonState)
@@ -424,6 +480,7 @@ class _OudsButtonState extends State<OudsButton> {
                 buttonState: buttonState,
                 navigationLayout: widget._navigationLayout,
                 componentType: widget._component,
+                size: widget._size,
               ),
               child: Stack(
                 alignment: Alignment.center,
@@ -431,8 +488,10 @@ class _OudsButtonState extends State<OudsButton> {
                   Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(null, size: buttonToken.sizeIconDefault),
-                      SizedBox(width: buttonToken.spaceColumnGapIconDefault),
+                      Icon(null, size: buttonToken.sizeIcon(widget._size)),
+                      SizedBox(
+                        width: buttonToken.spaceColumnGapIcon(widget._size),
+                      ),
                       Flexible(
                         fit: FlexFit.loose,
                         child: Opacity(
@@ -441,9 +500,7 @@ class _OudsButtonState extends State<OudsButton> {
                           ).opacityTokens.invisible,
                           child: Text(
                             widget.label ?? "",
-                            style: OudsTheme.of(
-                              context,
-                            ).typographyTokens.typeLabelStrongLarge(context),
+                            style: _labelTypography(context),
                           ),
                         ),
                       ),
@@ -488,6 +545,7 @@ class _OudsButtonState extends State<OudsButton> {
                     buttonState: buttonState,
                     navigationLayout: widget._navigationLayout,
                     componentType: widget._component,
+                    size: widget._size,
                   ),
                   child: Stack(
                     alignment: Alignment.center,
@@ -503,16 +561,14 @@ class _OudsButtonState extends State<OudsButton> {
                             buttonState,
                           ),
                           SizedBox(
-                            width: buttonToken.spaceColumnGapIconDefault,
+                            width: buttonToken.spaceColumnGapIcon(widget._size),
                           ),
                           Flexible(
                             fit: FlexFit.loose,
                             child: Text(
                               widget.label ?? "",
                               textAlign: TextAlign.center,
-                              style: OudsTheme.of(
-                                context,
-                              ).typographyTokens.typeLabelStrongLarge(context),
+                              style: _labelTypography(context),
                             ),
                           ),
                         ],
@@ -558,6 +614,7 @@ class _OudsButtonState extends State<OudsButton> {
                     buttonState: buttonState,
                     navigationLayout: widget._navigationLayout,
                     componentType: widget._component,
+                    size: widget._size,
                   ),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -566,13 +623,15 @@ class _OudsButtonState extends State<OudsButton> {
                         fit: FlexFit.loose,
                         child: Text(
                           widget.label ?? "",
-                          style: OudsTheme.of(context).typographyTokens
-                              .typeLabelStrongLarge(context)
-                              .copyWith(color: Colors.transparent),
+                          style: _labelTypography(
+                            context,
+                          ).copyWith(color: Colors.transparent),
                         ),
                       ),
-                      SizedBox(width: buttonToken.spaceColumnGapChevronDefault),
-                      Icon(null, size: buttonToken.sizeIconDefault),
+                      SizedBox(
+                        width: buttonToken.spaceColumnGapChevron(widget._size),
+                      ),
+                      Icon(null, size: buttonToken.sizeIcon(widget._size)),
                     ],
                   ),
                 ),
@@ -584,6 +643,7 @@ class _OudsButtonState extends State<OudsButton> {
                     buttonState: buttonState,
                     navigationLayout: widget._navigationLayout,
                     componentType: widget._component,
+                    size: widget._size,
                   ),
                   onPressed: null,
                   child: _buildLoadingIndicator(
@@ -620,6 +680,7 @@ class _OudsButtonState extends State<OudsButton> {
                     buttonState: buttonState,
                     navigationLayout: widget._navigationLayout,
                     componentType: widget._component,
+                    size: widget._size,
                   ),
                   child: isNextLayout
                       ? _buildNextNavigationButton(buttonState, buttonToken)
@@ -649,12 +710,10 @@ class _OudsButtonState extends State<OudsButton> {
           child: Text(
             widget.label ?? "",
             textAlign: TextAlign.center,
-            style: OudsTheme.of(
-              context,
-            ).typographyTokens.typeLabelStrongLarge(context),
+            style: _labelTypography(context),
           ),
         ),
-        SizedBox(width: buttonToken.spaceColumnGapChevronDefault),
+        SizedBox(width: buttonToken.spaceColumnGapChevron(widget._size)),
         _buildIcon(
           context,
           widget.icon!,
@@ -681,15 +740,13 @@ class _OudsButtonState extends State<OudsButton> {
           widget.layout,
           buttonState,
         ),
-        SizedBox(width: buttonToken.spaceColumnGapChevronDefault),
+        SizedBox(width: buttonToken.spaceColumnGapChevron(widget._size)),
         Flexible(
           fit: FlexFit.loose,
           child: Text(
             widget.label ?? "",
             textAlign: TextAlign.center,
-            style: OudsTheme.of(
-              context,
-            ).typographyTokens.typeLabelStrongLarge(context),
+            style: _labelTypography(context),
           ),
         ),
       ],
@@ -721,6 +778,7 @@ class _OudsButtonState extends State<OudsButton> {
               buttonState: buttonState,
               navigationLayout: widget._navigationLayout,
               componentType: widget._component,
+              size: widget._size,
             ),
             icon: Stack(
               alignment: Alignment.center,
@@ -757,7 +815,7 @@ class _OudsButtonState extends State<OudsButton> {
               enabled: widget.onPressed != null,
               child: ExcludeSemantics(
                 child: SizedBox(
-                  width: buttonToken.sizeMinWidthDefault,
+                  width: buttonToken.sizeMinWidth(widget._size),
                   child: IconButton(
                     focusNode: _focusNode,
                     style: OudsButtonStyleModifier.buildButtonStyle(
@@ -767,6 +825,7 @@ class _OudsButtonState extends State<OudsButton> {
                       buttonState: buttonState,
                       navigationLayout: widget._navigationLayout,
                       componentType: widget._component,
+                      size: widget._size,
                     ),
                     onPressed: widget.onPressed == null
                         ? null
@@ -808,6 +867,7 @@ class _OudsButtonState extends State<OudsButton> {
                 layout: widget.layout,
                 buttonState: buttonState,
                 componentType: widget._component,
+                size: widget._size,
               ),
               child: Stack(
                 alignment: Alignment.center,
@@ -816,9 +876,7 @@ class _OudsButtonState extends State<OudsButton> {
                     opacity: OudsTheme.of(context).opacityTokens.invisible,
                     child: Text(
                       widget.label ?? "",
-                      style: OudsTheme.of(
-                        context,
-                      ).typographyTokens.typeLabelStrongLarge(context),
+                      style: _labelTypography(context),
                     ),
                   ),
                   _buildLoadingIndicator(context, widget.loader?.progress),
@@ -837,6 +895,7 @@ class _OudsButtonState extends State<OudsButton> {
             layout: widget.layout,
             buttonState: buttonState,
             componentType: widget._component,
+            size: widget._size,
           ),
           onPressed: widget.onPressed == null
               ? null
@@ -844,9 +903,7 @@ class _OudsButtonState extends State<OudsButton> {
           child: Text(
             widget.label ?? "",
             textAlign: TextAlign.center,
-            style: OudsTheme.of(
-              context,
-            ).typographyTokens.typeLabelStrongLarge(context),
+            style: _labelTypography(context),
           ),
         );
         return _wrapFullWidth(buttonTextOnly);
@@ -860,20 +917,27 @@ class _OudsButtonState extends State<OudsButton> {
   Widget _buildLoadingIndicator(BuildContext context, double? progress) {
     {
       final clampedProgress = progress?.clamp(0.0, 1.0);
-      return SizedBox(
-        width: OudsTheme.of(
-          context,
-        ).componentsTokens(context).button.sizeProgressIndicatorDefault,
-        height: OudsTheme.of(
-          context,
-        ).componentsTokens(context).button.sizeProgressIndicatorDefault,
-        child: CircularProgressIndicator(
-          value: clampedProgress,
-          color: OudsButtonLoadingModifier.getColorToken(
-            context,
-            widget.appearance,
+      final progressIndicatorSize = OudsTheme.of(
+        context,
+      ).componentsTokens(context).button.sizeProgressIndicator(widget._size);
+      return Padding(
+        padding: EdgeInsetsDirectional.all(
+          OudsTheme.of(context)
+              .componentsTokens(context)
+              .button
+              .spaceProgressIndicator(widget._size),
+        ),
+        child: SizedBox(
+          width: progressIndicatorSize,
+          height: progressIndicatorSize,
+          child: CircularProgressIndicator(
+            value: clampedProgress,
+            color: OudsButtonLoadingModifier.getColorToken(
+              context,
+              widget.appearance,
+            ),
+            strokeWidth: widget._size == OudsButtonSize.small ? 2 : 3,
           ),
-          strokeWidth: 3,
         ),
       );
     }
@@ -909,7 +973,11 @@ class _OudsButtonState extends State<OudsButton> {
   ) {
     // navigation button
     final textScaleFactor = MediaQuery.textScalerOf(context).scale(1.0);
-    final baseIconSize = OudsButtonIconModifier.getIconSize(context, layout);
+    final baseIconSize = OudsButtonIconModifier.getIconSize(
+      context,
+      layout,
+      size: widget._size,
+    );
     final scaledIconSize = baseIconSize * textScaleFactor.clamp(1.0, 2.0);
 
     if (widget._navigationLayout != null) {
@@ -938,8 +1006,16 @@ class _OudsButtonState extends State<OudsButton> {
             AppAssets.icons.componentButtonPrevious,
             matchTextDirection: true,
             fit: BoxFit.contain,
-            width: OudsButtonIconModifier.getIconSize(context, layout),
-            height: OudsButtonIconModifier.getIconSize(context, layout),
+            width: OudsButtonIconModifier.getIconSize(
+              context,
+              layout,
+              size: widget._size,
+            ),
+            height: OudsButtonIconModifier.getIconSize(
+              context,
+              layout,
+              size: widget._size,
+            ),
             colorFilter: ColorFilter.mode(
               OudsButtonIconModifier.getIconColor(
                 context,
@@ -959,8 +1035,16 @@ class _OudsButtonState extends State<OudsButton> {
       assetName,
       matchTextDirection: true,
       fit: BoxFit.contain,
-      width: OudsButtonIconModifier.getIconSize(context, layout),
-      height: OudsButtonIconModifier.getIconSize(context, layout),
+      width: OudsButtonIconModifier.getIconSize(
+        context,
+        layout,
+        size: widget._size,
+      ),
+      height: OudsButtonIconModifier.getIconSize(
+        context,
+        layout,
+        size: widget._size,
+      ),
       colorFilter: ColorFilter.mode(
         OudsButtonIconModifier.getIconColor(context, buttonState, appearance),
         BlendMode.srcIn,
@@ -1017,6 +1101,7 @@ enum OudsNavigationButtonLayout { next, previous }
 /// - [isFullWidth]: When `true`, the button expands to fill the full width. Defaults to `false`.
 /// - [semanticsLabel]: Accessibility label used in icon-only mode when no [label] is provided.
 /// - [package]: Package name to resolve the chevron asset when it comes from a package.
+/// - [size]: The button size based on its [OudsButtonSize], set to [OudsButtonSize.defaultSize] by default.
 ///
 /// ### Usage examples:
 ///
@@ -1051,6 +1136,7 @@ class OudsNavigationButton extends StatelessWidget {
   final String? package;
   final bool? isFullWidth;
   final String? semanticsLabel;
+  final OudsButtonSize size;
 
   const OudsNavigationButton({
     super.key,
@@ -1062,6 +1148,7 @@ class OudsNavigationButton extends StatelessWidget {
     this.loader,
     this.isFullWidth,
     this.semanticsLabel,
+    this.size = OudsButtonSize.defaultSize,
   });
 
   @override
@@ -1087,6 +1174,7 @@ class OudsNavigationButton extends StatelessWidget {
       isFullWidth: isFullWidth,
       loader: loader,
       semanticsLabel: semanticsLabel,
+      size: size,
     );
   }
 

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -54,6 +54,9 @@ enum OudsButtonAppearance {
 ///   Values outside of this range are coerced into the range.
 ///  Set this value to `null` to display a circular indeterminate progress indicator.
 ///
+@Deprecated(
+  "This class is deprecated and will be removed in a future version. Use the isLoading boolean parameter instead.",
+)
 class Loader {
   final double? progress;
   Loader({this.progress});
@@ -113,9 +116,9 @@ enum OudsButtonComponent {
 /// - [label]: Label displayed in the button which describes the button action. Use action verbs or phrases to tell the user what will happen next.
 /// - [icon]: Icon displayed in the button. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
 /// - [onPressed]: Callback invoked when the button is clicked.
-///   Controls the enabled state of the button when [loader] is equal to null.
-///   When `false`, this button will not be clickable. Has no effect when [loader] is not null.
-/// - [loader]: An optional loading progress indicator displayed in the button to indicate an ongoing operation.
+///   Controls the enabled state of the button when [isLoading] is equal to false.
+///   When `false`, this button will not be clickable. Has no effect when [isLoading] is true.
+/// - [isLoading]: An optional loading progress indicator displayed in the button to indicate an ongoing operation.
 /// - [appearance]: The button appearance based on its [OudsButtonAppearance].
 ///   A button with [OudsButtonAppearance.negative] appearance is not allowed as a direct or indirect child of an [OudsColoredBox] and will throw an [IllegalStateException].
 ///   To create the widget with an asset from a package, the [package] argument
@@ -147,7 +150,7 @@ enum OudsButtonComponent {
 /// OudsButton(
 ///       isFullWidth: false,
 ///       label: 'Button',
-///       loader: Loader(progress: null),
+///       isLoading: true,
 ///       appearance: OudsButtonAppearance.defaultAppearance
 ///       onPressed: () {
 ///         // Handle button tap.
@@ -171,7 +174,11 @@ class OudsButton extends StatefulWidget {
   final String? label;
   final String? icon;
   final VoidCallback? onPressed;
+  @Deprecated(
+    "This parameter is deprecated and will be removed in a future version. Use isLoading instead.",
+  )
   final Loader? loader;
+  final bool? isLoading;
   final OudsButtonAppearance appearance;
   final String? package;
   final bool? isFullWidth;
@@ -197,6 +204,7 @@ class OudsButton extends StatefulWidget {
     this.icon,
     this.onPressed,
     this.loader,
+    this.isLoading = false,
     required this.appearance,
     this.package,
     this.isFullWidth = false,
@@ -225,6 +233,7 @@ class OudsButton extends StatefulWidget {
     this.icon,
     this.onPressed,
     this.loader,
+    this.isLoading = false,
     required this.appearance,
     this.package,
     this.isFullWidth = false,
@@ -245,6 +254,7 @@ class OudsButton extends StatefulWidget {
     this.isFullWidth = false,
     OudsButtonSize size = OudsButtonSize.defaultSize,
     this.loader,
+    this.isLoading = false,
     required OudsNavigationButtonLayout navigationLayout,
     String? semanticsLabel,
   }) : _size = size,
@@ -372,7 +382,7 @@ class _OudsButtonState extends State<OudsButton> {
       isPressed: _isPressed,
       isHovered: _isHovered,
       isFocused: _isFocused,
-      isLoading: widget.loader != null,
+      isLoading: widget.loader != null || widget.isLoading == true,
     );
     final buttonState = buttonStateDeterminer.determineControlState();
     final borderTokens = OudsTheme.of(context).borderTokens;
@@ -1092,7 +1102,7 @@ enum OudsNavigationButtonLayout { next, previous }
 /// - [appearance]: Visual importance of the button. **Required.**
 /// - [label]: Optional text label describing the navigation action.
 /// - [onPressed]: Callback invoked on tap. Pass `null` to disable the button.
-/// - [loader]: Optional [Loader] displaying a loading indicator inside the button.
+/// - [isLoading]: An optional loading progress indicator displayed in the button to indicate an ongoing operation.
 /// - [isFullWidth]: When `true`, the button expands to fill the full width. Defaults to `false`.
 /// - [semanticsLabel]: Accessibility label used in icon-only mode when no [label] is provided.
 /// - [package]: Package name to resolve the chevron asset when it comes from a package.
@@ -1127,7 +1137,11 @@ class OudsNavigationButton extends StatelessWidget {
   final OudsNavigationButtonAppearance appearance;
   final String? label;
   final VoidCallback? onPressed;
+  @Deprecated(
+    "This parameter is deprecated and will be removed in a future version. Use isLoading instead.",
+  )
   final Loader? loader;
+  final bool? isLoading;
   final String? package;
   final bool? isFullWidth;
   final String? semanticsLabel;
@@ -1141,6 +1155,7 @@ class OudsNavigationButton extends StatelessWidget {
     required this.appearance,
     this.package,
     this.loader,
+    this.isLoading = false,
     this.isFullWidth,
     this.semanticsLabel,
     this.size = OudsButtonSize.defaultSize,
@@ -1168,6 +1183,7 @@ class OudsNavigationButton extends StatelessWidget {
       navigationLayout: layout,
       isFullWidth: isFullWidth,
       loader: loader,
+      isLoading: isLoading,
       semanticsLabel: semanticsLabel,
       size: size,
     );

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -23,12 +23,14 @@ import 'package:ouds_core/components/button/internal/ouds_button_loading_modifie
 import 'package:ouds_core/components/button/internal/ouds_button_style_modifier.dart';
 import 'package:ouds_core/components/button/internal/ouds_button_utils.dart';
 import 'package:ouds_core/components/common/OudsBorder.dart';
+import 'package:ouds_core/components/progress_indicator/ouds_progress_indicator.dart';
 import 'package:ouds_core/components/top_bar/ouds_top_bar.dart';
 import 'package:ouds_core/components/utilities/app_assets.dart';
 import 'package:ouds_core/l10n/gen/ouds_localizations.dart';
 import 'package:ouds_theme_contract/ouds_theme.dart';
 import 'package:ouds_theme_contract/theme/tokens/components/ouds_button_tokens.dart';
 
+/// The [OudsButtonAppearance] enum defines the visual importance of the button within the UI.
 /// Defines the visual importance (appearance) of an [OudsButton] within the UI.
 ///
 /// Use this enum to control the emphasis level of a button:
@@ -486,21 +488,20 @@ class _OudsButtonState extends State<OudsButton> {
           enabled: false,
           button: true,
           child: ExcludeSemantics(
-            child: OutlinedButton(
-              onPressed: null,
-              style: OudsButtonStyleModifier.buildButtonStyle(
-                context,
-                appearance: widget.appearance,
-                layout: widget.layout,
-                buttonState: buttonState,
-                navigationLayout: widget._navigationLayout,
-                componentType: widget._component,
-                size: widget._size,
-              ),
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  Row(
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                OutlinedButton(
+                  onPressed: null,
+                  style: OudsButtonStyleModifier.buildButtonStyle(
+                    context,
+                    appearance: widget.appearance,
+                    layout: widget.layout,
+                    buttonState: buttonState,
+                    navigationLayout: widget._navigationLayout,
+                    componentType: widget._component,
+                  ),
+                  child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Icon(null, size: buttonToken.sizeIcon(widget._size)),
@@ -521,17 +522,20 @@ class _OudsButtonState extends State<OudsButton> {
                       ),
                     ],
                   ),
-                  Padding(
-                    padding: EdgeInsetsDirectional.only(
-                      start: buttonToken.spaceColumnGapIconDefault,
-                    ),
-                    child: _buildLoadingIndicator(
-                      context,
-                      widget.loader?.progress,
-                    ),
+                ),
+                OutlinedButton(
+                  style: OudsButtonStyleModifier.buildButtonStyle(
+                    context,
+                    appearance: OudsButtonAppearance.minimal,
+                    layout: OudsButtonLayout.iconOnly,
+                    buttonState: buttonState,
+                    navigationLayout: widget._navigationLayout,
+                    componentType: widget._component,
                   ),
-                ],
-              ),
+                  onPressed: null,
+                  child: _buildLoadingIndicator(context),
+                ),
+              ],
             ),
           ),
         );
@@ -661,10 +665,7 @@ class _OudsButtonState extends State<OudsButton> {
                     size: widget._size,
                   ),
                   onPressed: null,
-                  child: _buildLoadingIndicator(
-                    context,
-                    widget.loader?.progress,
-                  ),
+                  child: _buildLoadingIndicator(context),
                 ),
               ],
             ),
@@ -789,27 +790,17 @@ class _OudsButtonState extends State<OudsButton> {
             style: OudsButtonStyleModifier.buildButtonStyle(
               context,
               appearance: widget.appearance,
-              layout: widget.layout,
+              layout: OudsButtonLayout.iconOnly,
               buttonState: buttonState,
               navigationLayout: widget._navigationLayout,
               componentType: widget._component,
               size: widget._size,
             ),
-            icon: Stack(
-              alignment: Alignment.center,
-              children: [
-                Opacity(
-                  opacity: OudsTheme.of(context).opacityTokens.invisible,
-                  child: _buildIcon(
-                    context,
-                    widget.icon!,
-                    widget.appearance,
-                    widget.layout,
-                    buttonState,
-                  ),
-                ),
-                _buildLoadingIndicator(context, widget.loader?.progress),
-              ],
+            icon: Padding(
+              padding: EdgeInsets.all(
+                buttonToken.spaceInsetProgressIndicatorOnlyDefault,
+              ),
+              child: _buildLoadingIndicator(context),
             ),
           ),
         );
@@ -894,7 +885,7 @@ class _OudsButtonState extends State<OudsButton> {
                       style: _labelTypography(context),
                     ),
                   ),
-                  _buildLoadingIndicator(context, widget.loader?.progress),
+                  _buildLoadingIndicator(context),
                 ],
               ),
             ),
@@ -925,34 +916,23 @@ class _OudsButtonState extends State<OudsButton> {
     }
   }
 
-  /// Builds the circular loading indicator shown inside the button during a loading state.
-  ///
-  /// [progress] is clamped to `[0.0, 1.0]`. Pass `null` for an indeterminate spinner.
-  //todo will be replaced by OudsCircularProgressIndicator when it will be available in core
-  Widget _buildLoadingIndicator(BuildContext context, double? progress) {
+  /// Builds the [OudsCircularProgressIndicator] shown inside the button during a loading state.
+  Widget _buildLoadingIndicator(BuildContext context) {
     {
-      final clampedProgress = progress?.clamp(0.0, 1.0);
       final progressIndicatorSize = OudsTheme.of(
         context,
       ).componentsTokens(context).button.sizeProgressIndicator(widget._size);
-      return Padding(
-        padding: EdgeInsetsDirectional.all(
-          OudsTheme.of(context)
-              .componentsTokens(context)
-              .button
-              .spaceProgressIndicator(widget._size),
-        ),
-        child: SizedBox(
-          width: progressIndicatorSize,
-          height: progressIndicatorSize,
-          child: CircularProgressIndicator(
-            value: clampedProgress,
-            color: OudsButtonLoadingModifier.getColorToken(
-              context,
-              widget.appearance,
-            ),
-            strokeWidth: widget._size == OudsButtonSize.small ? 2 : 3,
+
+      return SizedBox(
+        width: progressIndicatorSize,
+        height: progressIndicatorSize,
+        child: OudsCircularProgressIndicator.internal(
+          progressType: OudsProgressIndicatorType.indeterminate,
+          color: OudsButtonLoadingModifier.getColorToken(
+            context,
+            widget.appearance,
           ),
+          track: false,
         ),
       );
     }

--- a/ouds_core/lib/components/button/ouds_button.dart
+++ b/ouds_core/lib/components/button/ouds_button.dart
@@ -92,13 +92,16 @@ enum OudsButtonComponent {
 
 /// [OUDS Button design guidelines](https://r.orange.fr/r/S-ouds-doc-button)
 ///
-/// **Reference design version : 3.2.0**
+/// **Reference design version : 3.3.0**
 ///
 /// Button is a UI element that triggers an action or event, and is used to initiate tasks or confirming an action.
 /// Button appears in different layouts, styles and states to indicate hierarchy or emphasis.
 ///
 /// This version of the button uses the *text only* layout which is the most used layout.
 /// Other layouts are available for this component: *text + icon* and *icon only*.
+///
+/// This is the default size of the component. This size is used for the vast majority of applications.
+/// A small size is also available via [OudsButton.small].
 ///
 /// Note that in the case it is placed in an [OudsColoredBox], its monochrome variant is automatically displayed.
 /// Some tokens associated with these specific colors can be customized and are identified with the `Mono` suffix (for instance [OudsButtonTokens.colorBgDefaultEnabledMono]).
@@ -122,7 +125,7 @@ enum OudsButtonComponent {
 ///
 /// ### Text only button :
 ///
-/// This is the default layout of the component.
+/// **This is the default layout of the component:**
 ///
 /// ```dart
 /// OudsButton(
@@ -134,9 +137,10 @@ enum OudsButtonComponent {
 ///      },
 ///     );
 /// ```
-/// ```dart
 ///
-/// This is the Loading layout of the component.
+/// **This is the Loading layout of the component:**
+///
+/// ```dart
 ///
 /// OudsButton(
 ///       isFullWidth: false,
@@ -149,7 +153,7 @@ enum OudsButtonComponent {
 ///     );
 /// ```
 ///
-/// ### Small text only button :
+/// ### Small button with text only :
 ///
 /// ```dart
 /// OudsButton.small(

--- a/ouds_core/lib/components/form_input/ouds_phone_number_input.dart
+++ b/ouds_core/lib/components/form_input/ouds_phone_number_input.dart
@@ -855,7 +855,7 @@ class _OudsPhoneNumberInputState extends State<OudsPhoneNumberInput> {
             icon: AppAssets.icons.functionalSocialAndEngagementHeartEmpty,
             package: OudsTheme.of(context).packageName,
             appearance: OudsButtonAppearance.minimal,
-            loader: Loader(progress: null),
+            isLoading: true,
             onPressed: () {},
           ),
         ],

--- a/ouds_core/lib/components/form_input/password_input/ouds_password_input.dart
+++ b/ouds_core/lib/components/form_input/password_input/ouds_password_input.dart
@@ -566,7 +566,7 @@ class _OudsPasswordInputState extends State<OudsPasswordInput> {
           OudsButton(
             icon: 'assets/ic_password_lock.svg',
             appearance: OudsButtonAppearance.minimal,
-            loader: Loader(progress: null),
+            isLoading: true,
             onPressed: () {},
           ),
         ],


### PR DESCRIPTION


_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues


### Description

- #832

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/DEVELOP.md)
- [NA] I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] Manually test (dark mode, RTL, landscape display, tablet)
- [x] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- [NA] Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [x] CHANGELOG.md files have been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
