### PR TITLE
feat(chip): In library, update chips components to v1.5.0 #837

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -138,6 +138,37 @@ OudsFilterChip.icon(
 
 **Reason for Change**: Align `OudsFilterChip`'s icon parameter naming with its own `.icon` named constructor, avoiding two different parameter names (`avatar` vs `icon`) for the same purpose
 
+#### 6. `OudsSuggestionChip` — `avatar` parameter deprecated in favor of `OudsSuggestionChip.icon`
+
+The `avatar` parameter of the default `OudsSuggestionChip()` constructor is now **deprecated**. Use the new `OudsSuggestionChip.icon` named constructor with its `icon` parameter instead, for consistency with `OudsFilterChip`. This named constructor also introduces a `tinted` parameter to control whether the icon is tinted with the theme color, and a `contentDescription` parameter for accessibility on icon-only chips.
+
+**Impact**: Low (additive — `avatar` still works but should be migrated)
+
+**Before**:
+```dart
+OudsSuggestionChip(
+  label: 'Label',
+  avatar: 'assets/ic_chip_heart.svg',
+  onPressed: () {},
+)
+```
+
+**After**:
+```dart
+OudsSuggestionChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  tinted: true,
+  onPressed: () {},
+)
+```
+
+**Required Action**:
+- Replace `OudsSuggestionChip(avatar: ...)` with `OudsSuggestionChip.icon(icon: ...)`
+- Text-only suggestion chips keep using the default `OudsSuggestionChip(...)` constructor unchanged
+
+**Reason for Change**: Align `OudsSuggestionChip`'s icon parameter naming with `OudsFilterChip`'s `.icon` named constructor, avoiding two different parameter names (`avatar` vs `icon`) for the same purpose
+
 ### Component Design Version Updates
 
 Several components have been updated to align with new design specification versions. These changes are primarily visual and do not require code changes unless you override component tokens in a custom theme.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -106,6 +106,38 @@ OudsLink.external(label: 'Label')
 
 **Reason for Change**: Improve type safety and API clarity by making each link variant explicit through its own constructor, consistent with `OudsTag` and `OudsBadge`
 
+#### 5. `OudsFilterChip` — `avatar` parameter deprecated in favor of `OudsFilterChip.icon`
+
+The `avatar` parameter of the default `OudsFilterChip()` constructor is now **deprecated**. Use the `OudsFilterChip.icon` named constructor with its `icon` parameter instead, for consistency with the rest of the API.
+
+**Impact**: Low (additive — `avatar` still works but should be migrated)
+
+**Before**:
+```dart
+OudsFilterChip(
+  label: 'Label',
+  avatar: 'assets/ic_chip_heart.svg',
+  selected: true,
+  onSelected: (bool selected) {},
+)
+```
+
+**After**:
+```dart
+OudsFilterChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  selected: true,
+  onSelected: (bool selected) {},
+)
+```
+
+**Required Action**:
+- Replace `OudsFilterChip(avatar: ...)` with `OudsFilterChip.icon(icon: ...)`
+- Text-only filter chips keep using the default `OudsFilterChip(...)` constructor unchanged
+
+**Reason for Change**: Align `OudsFilterChip`'s icon parameter naming with its own `.icon` named constructor, avoiding two different parameter names (`avatar` vs `icon`) for the same purpose
+
 ### Component Design Version Updates
 
 Several components have been updated to align with new design specification versions. These changes are primarily visual and do not require code changes unless you override component tokens in a custom theme.

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [DemoApp][Library] Create component - `List item` ([#54](https://github.com/Orange-OpenSource/ouds-flutter/issues/54))
 ### Changed
+- [DemoApp][Library] In library, update chips components to v1.5.0 ([#837](https://github.com/Orange-OpenSource/ouds-flutter/issues/837))
 - [DemoApp] deps update dependency: bump archive from 3.6.1 to 4.2.0 ([#909](https://github.com/Orange-OpenSource/ouds-flutter/issues/909))
 - [Library] Add typography Tokens component ([#905](https://github.com/Orange-OpenSource/ouds-flutter/issues/905))
 - [DemoApp][Library] update icons to use the icons pack 2.3.0 ([#863](https://github.com/Orange-OpenSource/ouds-flutter/issues/863))

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations.dart
@@ -175,11 +175,11 @@ abstract class AppLocalizations {
   /// **'Please select a chip by navigating through the options'**
   String get app_common_customizeChipsHint_a11y;
 
-  /// No description provided for @app_common_selected_label.
+  /// No description provided for @app_common_selected_tech.
   ///
   /// In en, this message translates to:
   /// **'Selected'**
-  String get app_common_selected_label;
+  String get app_common_selected_tech;
 
   /// No description provided for @app_topBar_theme_button_a11y.
   ///
@@ -631,11 +631,23 @@ abstract class AppLocalizations {
   /// **'Type'**
   String get app_components_common_type_tech;
 
+  /// No description provided for @app_components_common_icon_tech.
+  ///
+  /// In en, this message translates to:
+  /// **'Icon'**
+  String get app_components_common_icon_tech;
+
   /// No description provided for @app_components_common_tinted_tech.
   ///
   /// In en, this message translates to:
-  /// **'Tinted icon'**
+  /// **'Tinted'**
   String get app_components_common_tinted_tech;
+
+  /// No description provided for @app_components_common_untinted_tech.
+  ///
+  /// In en, this message translates to:
+  /// **'Untinted'**
+  String get app_components_common_untinted_tech;
 
   /// No description provided for @app_components_alert_tech.
   ///

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_ar.dart
@@ -49,7 +49,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'يرجى اختيار Chip من خلال التنقل بين الخيارات';
 
   @override
-  String get app_common_selected_label => 'Selected';
+  String get app_common_selected_tech => 'Selected';
 
   @override
   String get app_topBar_theme_button_a11y => 'تغيير السمة';
@@ -290,7 +290,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get app_components_common_type_tech => 'Type';
 
   @override
-  String get app_components_common_tinted_tech => 'Tinted icon';
+  String get app_components_common_icon_tech => 'Icon';
+
+  @override
+  String get app_components_common_tinted_tech => 'Tinted';
+
+  @override
+  String get app_components_common_untinted_tech => 'Untinted';
 
   @override
   String get app_components_alert_tech => 'Alert';

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_en.dart
@@ -49,7 +49,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Please select a chip by navigating through the options';
 
   @override
-  String get app_common_selected_label => 'Selected';
+  String get app_common_selected_tech => 'Selected';
 
   @override
   String get app_topBar_theme_button_a11y => 'Change theme';
@@ -290,7 +290,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get app_components_common_type_tech => 'Type';
 
   @override
-  String get app_components_common_tinted_tech => 'Tinted icon';
+  String get app_components_common_icon_tech => 'Icon';
+
+  @override
+  String get app_components_common_tinted_tech => 'Tinted';
+
+  @override
+  String get app_components_common_untinted_tech => 'Untinted';
 
   @override
   String get app_components_alert_tech => 'Alert';

--- a/app/lib/l10n/gen/ouds_flutter_app_localizations_fr.dart
+++ b/app/lib/l10n/gen/ouds_flutter_app_localizations_fr.dart
@@ -49,7 +49,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Veuillez sélectionner une puce en naviguant parmi les options';
 
   @override
-  String get app_common_selected_label => 'Sélectionné';
+  String get app_common_selected_tech => 'Selected';
 
   @override
   String get app_topBar_theme_button_a11y => 'Changer le thème';
@@ -292,7 +292,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get app_components_common_type_tech => 'Type';
 
   @override
-  String get app_components_common_tinted_tech => 'Tinted icon';
+  String get app_components_common_icon_tech => 'Icon';
+
+  @override
+  String get app_components_common_tinted_tech => 'Tinted';
+
+  @override
+  String get app_components_common_untinted_tech => 'Untinted';
 
   @override
   String get app_components_alert_tech => 'Alert';

--- a/app/lib/l10n/ouds_flutter_en.arb
+++ b/app/lib/l10n/ouds_flutter_en.arb
@@ -13,7 +13,7 @@
   "app_common_enabled_label": "Enabled",
   "app_common_customizeChipList_a11y": "Chip list",
   "app_common_customizeChipsHint_a11y": "Please select a chip by navigating through the options",
-  "app_common_selected_label": "Selected",
+  "app_common_selected_tech": "Selected",
 
   "@_top_bar": {},
   "app_topBar_theme_button_a11y": "Change theme",
@@ -138,7 +138,9 @@
   "app_components_common_description_tech": "Description",
   "app_components_common_edgeToEdge_tech": "Edge to edge",
   "app_components_common_type_tech" : "Type",
-  "app_components_common_tinted_tech": "Tinted icon",
+  "app_components_common_icon_tech": "Icon",
+  "app_components_common_tinted_tech": "Tinted",
+  "app_components_common_untinted_tech": "Untinted",
 
   "@_components_alert": {},
   "app_components_alert_tech": "Alert",

--- a/app/lib/l10n/ouds_flutter_fr.arb
+++ b/app/lib/l10n/ouds_flutter_fr.arb
@@ -12,7 +12,6 @@
   "app_common_customize_label": "Personnaliser",
   "app_common_customizeChipList_a11y": "Liste de puces",
   "app_common_customizeChipsHint_a11y": "Veuillez sélectionner une puce en naviguant parmi les options",
-  "app_common_selected_label": "Sélectionné",
 
 
   "@_top_bar": {},

--- a/app/lib/ui/components/chip/chip_customization.dart
+++ b/app/lib/ui/components/chip/chip_customization.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_widget_state.dart';
+import 'package:ouds_flutter_demo/ui/utilities/customizable/tinted_enum.dart';
 
 import 'chip_enum.dart';
 
 /// Section for InheritedWidget to pass data down the widget tree
 class _ChipCustomization extends InheritedWidget {
-  const _ChipCustomization({
-    required super.child,
-    required this.data,
-  });
+  const _ChipCustomization({required super.child, required this.data});
 
   final ChipCustomizationState data;
 
@@ -18,10 +16,7 @@ class _ChipCustomization extends InheritedWidget {
 
 /// Main Widget class for chip customization
 class ChipCustomization extends StatefulWidget {
-  const ChipCustomization({
-    super.key,
-    required this.child,
-  });
+  const ChipCustomization({super.key, required this.child});
 
   final Widget child;
 
@@ -29,20 +24,24 @@ class ChipCustomization extends StatefulWidget {
   ChipCustomizationState createState() => ChipCustomizationState();
 
   static ChipCustomizationState? of(BuildContext context) {
-    return (context.dependOnInheritedWidgetOfExactType<_ChipCustomization>())?.data;
+    return (context.dependOnInheritedWidgetOfExactType<_ChipCustomization>())
+        ?.data;
   }
 }
 
 /// Chip customization state management
-class ChipCustomizationState extends CustomizationWidgetState<ChipCustomization> {
+class ChipCustomizationState
+    extends CustomizationWidgetState<ChipCustomization> {
   late final LayoutState layoutState;
   late final LabelTextState labelTextState;
+  late final TintedIconState tintedIconState;
 
   @override
   void initState() {
     super.initState();
     layoutState = LayoutState(setState);
     labelTextState = LabelTextState(setState);
+    tintedIconState = TintedIconState(setState);
   }
 
   ChipEnumLayout get selectedLayout => layoutState.selected;
@@ -52,15 +51,17 @@ class ChipCustomizationState extends CustomizationWidgetState<ChipCustomization>
   String get labelText => labelTextState.value;
   set labelText(String value) => labelTextState.value = value;
 
+  // Proxy getters and setters to expose tinted state values directly
+  bool get tintedIcon => tintedIconState.selected == TintedEnum.tinted;
+  set tintedIcon(bool value) => tintedIconState.selected = value
+      ? TintedEnum.tinted
+      : TintedEnum.untinted;
+
   @override
   Widget build(BuildContext context) {
-    return _ChipCustomization(
-      data: this,
-      child: widget.child,
-    );
+    return _ChipCustomization(data: this, child: widget.child);
   }
 }
-
 
 /// Layout State Management
 class LayoutState {
@@ -95,6 +96,24 @@ class LabelTextState {
   set value(String newValue) {
     _setState(() {
       _labelTextValue = newValue;
+    });
+  }
+}
+
+/// TintedIcon State Management
+class TintedIconState {
+  TintedIconState(this._setState);
+  final void Function(VoidCallback) _setState;
+
+  final List<TintedEnum> _tinted = [TintedEnum.tinted, TintedEnum.untinted];
+
+  List<TintedEnum> get list => _tinted;
+
+  TintedEnum _selected = TintedEnum.tinted;
+  TintedEnum get selected => _selected;
+  set selected(TintedEnum newValue) {
+    _setState(() {
+      _selected = newValue;
     });
   }
 }

--- a/app/lib/ui/components/chip/chip_customization_utils.dart
+++ b/app/lib/ui/components/chip/chip_customization_utils.dart
@@ -42,12 +42,13 @@ class ChipCustomizationUtils {
   static String? getIcon(
     ChipCustomizationState? customizationState,
     ThemeController themeController,
+    bool isTinted,
   ) {
     if (customizationState?.selectedLayout == ChipEnumLayout.iconOnly ||
         customizationState?.selectedLayout == ChipEnumLayout.iconAndText) {
-      return AppAssets.icons.functionalSocialAndEngagementHeartRecommend(
-        themeController,
-      );
+      return isTinted
+          ? AppAssets.icons.assistanceTipsAndTricks(themeController)
+          : AppAssets.icons.icUntintedSquare;
     }
     return null;
   }

--- a/app/lib/ui/components/chip/chip_filter_code_generator.dart
+++ b/app/lib/ui/components/chip/chip_filter_code_generator.dart
@@ -26,28 +26,35 @@ class ChipFilterCodeGenerator {
   // Static method to generate the code based on chip customization state
   static String updateCode(BuildContext context) {
     // Fetch the current chip customization state from context
-    final ChipCustomizationState? customizationState = ChipCustomization.of(context);
+    final ChipCustomizationState? customizationState = ChipCustomization.of(
+      context,
+    );
 
     // Get the text value for the chip from customization state
     String label = customizationState?.labelText ?? "Label";
 
     // Get the chip's layout from customization state
-    OudsChipLayout layout = ChipCustomizationUtils.getLayout(customizationState?.selectedLayout as Object);
+    OudsChipLayout layout = ChipCustomizationUtils.getLayout(
+      customizationState?.selectedLayout as Object,
+    );
 
     String code = '';
 
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsChipLayout.textOnly:
-        code = """OudsFilterChip(\nlabel: "$label",\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);""";
+        code =
+            """OudsFilterChip(\nlabel: "$label",\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);""";
         break;
 
       case OudsChipLayout.iconOnly:
-        code = "OudsFilterChip(\navatar: 'assets/ic_chip_heart.svg',\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);";
+        code =
+            "OudsFilterChip.icon(\nicon: 'assets/ic_chip_heart.svg',\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);";
         break;
 
       case OudsChipLayout.iconAndText:
-        code = """OudsFilterChip(\nlabel: "$label",\navatar: 'assets/ic_chip_heart.svg',\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);""";
+        code =
+            """OudsFilterChip.icon(\nlabel: "$label",\nicon: 'assets/ic_chip_heart.svg',\nselected: ${customizationState?.hasSelected == true ? "true" : 'false'},\n${disableCode(context)}\n);""";
         break;
     }
 
@@ -56,11 +63,13 @@ class ChipFilterCodeGenerator {
 
   // Method to generate the disable code for the checkbox onChanged callback
   static String disableCode(BuildContext context) {
-    final ChipCustomizationState? customizationState = ChipCustomization.of(context);
+    final ChipCustomizationState? customizationState = ChipCustomization.of(
+      context,
+    );
     // Return the onChanged callback code with its enabled or disabled state
     return "onSelected: ${customizationState?.hasEnabled == true ? "(bool newValue) { \n"
-        "setState(() {\n "
-        "isSelected = newValue;\n "
-        "});\n}" : 'null'},";
+              "setState(() {\n "
+              "isSelected = newValue;\n "
+              "});\n}" : 'null'},";
   }
 }

--- a/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
+++ b/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
@@ -195,8 +195,18 @@ class _ChipFilterDemoState extends State<_ChipFilterDemo> {
                 }
               : null,
         );
-      case null:
-        throw UnimplementedError();
+      default:
+        return OudsFilterChip(
+          label: ChipCustomizationUtils.getText(customizationState),
+          selected: customizationState!.hasSelected,
+          onSelected: customizationState.hasEnabled == true
+              ? (newValue) {
+                  setState(() {
+                    customizationState.hasSelected = newValue;
+                  });
+                }
+              : null,
+        );
     }
   }
 }

--- a/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
+++ b/app/lib/ui/components/chip/chip_filter_demo_sreen.dart
@@ -25,6 +25,7 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_chips.d
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
+import 'package:ouds_flutter_demo/ui/utilities/customizable/tinted_enum.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/dismiss_keyboard.dart';
 import 'package:ouds_flutter_demo/ui/utilities/light_dark_box.dart';
@@ -133,32 +134,70 @@ class _ChipFilterDemo extends StatefulWidget {
 }
 
 class _ChipFilterDemoState extends State<_ChipFilterDemo> {
-  ThemeController? themeController;
-  ChipCustomizationState? customizationState;
-  bool isSelected = false;
-
   @override
   Widget build(BuildContext context) {
-    customizationState = ChipCustomization.of(context);
-    themeController = Provider.of<ThemeController>(context, listen: true);
+    return LightDarkBox(child: _buildOudsFilterChip(context));
+  }
 
-    return LightDarkBox(
-      child: OudsFilterChip(
-        label: ChipCustomizationUtils.getText(customizationState),
-        avatar: ChipCustomizationUtils.getIcon(
-          customizationState,
-          themeController!,
-        ),
-        selected: customizationState?.hasSelected,
-        onSelected: customizationState?.hasEnabled == true
-            ? (newValue) {
-                setState(() {
-                  customizationState?.hasSelected = newValue;
-                });
-              }
-            : null,
-      ),
+  Widget _buildOudsFilterChip(BuildContext context) {
+    ChipCustomizationState? customizationState = ChipCustomization.of(context);
+    ThemeController? themeController = Provider.of<ThemeController>(
+      context,
+      listen: true,
     );
+
+    switch (customizationState?.selectedLayout) {
+      case ChipEnumLayout.textOnly:
+        return OudsFilterChip(
+          label: ChipCustomizationUtils.getText(customizationState),
+          selected: customizationState!.hasSelected,
+          onSelected: customizationState.hasEnabled == true
+              ? (newValue) {
+                  setState(() {
+                    customizationState.hasSelected = newValue;
+                  });
+                }
+              : null,
+        );
+      case ChipEnumLayout.iconAndText:
+        return OudsFilterChip.icon(
+          label: ChipCustomizationUtils.getText(customizationState),
+          icon: ChipCustomizationUtils.getIcon(
+            customizationState,
+            themeController,
+            customizationState!.tintedIcon,
+          ),
+          tinted: customizationState.tintedIcon,
+          selected: customizationState.hasSelected,
+          onSelected: customizationState.hasEnabled == true
+              ? (newValue) {
+                  setState(() {
+                    customizationState.hasSelected = newValue;
+                  });
+                }
+              : null,
+        );
+      case ChipEnumLayout.iconOnly:
+        return OudsFilterChip.icon(
+          icon: ChipCustomizationUtils.getIcon(
+            customizationState,
+            themeController,
+            customizationState!.tintedIcon,
+          ),
+          contentDescription: context.l10n.app_components_common_icon_a11y,
+          tinted: customizationState.tintedIcon,
+          selected: customizationState.hasSelected,
+          onSelected: customizationState.hasEnabled == true
+              ? (newValue) {
+                  setState(() {
+                    customizationState.hasSelected = newValue;
+                  });
+                }
+              : null,
+        );
+      case null:
+        throw UnimplementedError();
+    }
   }
 }
 
@@ -202,7 +241,7 @@ class _CustomizationContentState extends State<_CustomizationContent> {
           },
         ),
         CustomizableSwitch(
-          title: context.l10n.app_common_selected_label,
+          title: context.l10n.app_common_selected_tech,
           value: customizationState.hasSelected,
           onChanged: (value) {
             setState(() {
@@ -220,6 +259,23 @@ class _CustomizationContentState extends State<_CustomizationContent> {
               customizationState.selectedLayout = selectedOption;
             });
           },
+        ),
+        Visibility(
+          visible:
+              customizationState.selectedLayout == ChipEnumLayout.iconAndText ||
+              customizationState.selectedLayout == ChipEnumLayout.iconOnly,
+          child: CustomizableChips<TintedEnum>(
+            title: context.l10n.app_components_common_icon_tech,
+            options: customizationState.tintedIconState.list,
+            selectedOption: customizationState.tintedIconState.selected,
+            getText: (option) => option.stringValue(context),
+            onSelected: (selectedOption) {
+              setState(() {
+                customizationState.tintedIcon =
+                    selectedOption == TintedEnum.tinted;
+              });
+            },
+          ),
         ),
         CustomizableTextField(
           title: context.l10n.app_components_common_label_label,

--- a/app/lib/ui/components/chip/chip_suggestion_code_generator.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_code_generator.dart
@@ -26,28 +26,35 @@ class ChipSuggestionCodeGenerator {
   // Static method to generate the code based on chip customization state
   static String updateCode(BuildContext context) {
     // Fetch the current chip customization state from context
-    final ChipCustomizationState? customizationState = ChipCustomization.of(context);
+    final ChipCustomizationState? customizationState = ChipCustomization.of(
+      context,
+    );
 
     // Get the text value for the chip from customization state
     String label = customizationState?.labelText ?? "Label";
 
     // Get the chip's layout from customization state
-    OudsChipLayout layout = ChipCustomizationUtils.getLayout(customizationState?.selectedLayout as Object);
+    OudsChipLayout layout = ChipCustomizationUtils.getLayout(
+      customizationState?.selectedLayout as Object,
+    );
 
     String code = '';
 
     // Switch on the layout type and generate the corresponding code
     switch (layout) {
       case OudsChipLayout.textOnly:
-        code = """OudsSuggestionChip(\nlabel: "$label",\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);""";
+        code =
+            """OudsSuggestionChip(\nlabel: "$label",\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);""";
         break;
 
       case OudsChipLayout.iconOnly:
-        code = "OudsSuggestionChip(\navatar: 'assets/ic_heart.svg',\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);";
+        code =
+            "OudsSuggestionChip.icon(\nicon: 'assets/ic_heart.svg',\ntinted: ${customizationState?.tintedIcon == true ? "true" : 'false'},\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);";
         break;
 
       case OudsChipLayout.iconAndText:
-        code = """OudsSuggestionChip(\nlabel: "$label",\navatar: 'assets/ic_heart.svg',\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);""";
+        code =
+            """OudsSuggestionChip.icon(\nlabel: "$label",\nicon: 'assets/ic_heart.svg',\ntinted: ${customizationState?.tintedIcon == true ? "true" : 'false'},\nonPressed: ${customizationState?.hasEnabled == true ? "() {}" : 'null'},\n);""";
         break;
     }
 

--- a/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
@@ -154,14 +154,14 @@ class _ChipSuggestionDemoState extends State<_ChipSuggestionDemo> {
           onPressed: customizationState?.hasEnabled == true ? () {} : null,
         );
       case ChipEnumLayout.iconAndText:
-        return OudsSuggestionChip(
+        return OudsSuggestionChip.icon(
           label: ChipCustomizationUtils.getText(customizationState),
-          avatar: ChipCustomizationUtils.getIcon(
+          icon: ChipCustomizationUtils.getIcon(
             customizationState,
             themeController!,
             customizationState!.tintedIcon,
           ),
-          // tinted: customizationState!.tintedIcon,
+          tinted: customizationState!.tintedIcon,
           onPressed: customizationState!.hasEnabled == true ? () {} : null,
         );
       case ChipEnumLayout.iconOnly:
@@ -175,8 +175,12 @@ class _ChipSuggestionDemoState extends State<_ChipSuggestionDemo> {
           tinted: customizationState!.tintedIcon,
           onPressed: customizationState!.hasEnabled == true ? () {} : null,
         );
-      case null:
-        throw UnimplementedError();
+
+      default:
+        return OudsSuggestionChip(
+          label: ChipCustomizationUtils.getText(customizationState),
+          onPressed: customizationState?.hasEnabled == true ? () {} : null,
+        );
     }
   }
 }

--- a/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
@@ -148,6 +148,7 @@ class _ChipSuggestionDemoState extends State<_ChipSuggestionDemo> {
         avatar: ChipCustomizationUtils.getIcon(
           customizationState,
           themeController!,
+          false,
         ),
         onPressed: customizationState?.hasEnabled == true ? () {} : null,
       ),

--- a/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
+++ b/app/lib/ui/components/chip/chip_suggestion_demo_screen.dart
@@ -25,6 +25,7 @@ import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_chips.d
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_section.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_switch.dart';
 import 'package:ouds_flutter_demo/ui/utilities/customizable/customizable_textfield.dart';
+import 'package:ouds_flutter_demo/ui/utilities/customizable/tinted_enum.dart';
 import 'package:ouds_flutter_demo/ui/utilities/detail_screen_header.dart';
 import 'package:ouds_flutter_demo/ui/utilities/dismiss_keyboard.dart';
 import 'package:ouds_flutter_demo/ui/utilities/light_dark_box.dart';
@@ -142,17 +143,41 @@ class _ChipSuggestionDemoState extends State<_ChipSuggestionDemo> {
     customizationState = ChipCustomization.of(context);
     themeController = Provider.of<ThemeController>(context, listen: true);
 
-    return LightDarkBox(
-      child: OudsSuggestionChip(
-        label: ChipCustomizationUtils.getText(customizationState),
-        avatar: ChipCustomizationUtils.getIcon(
-          customizationState,
-          themeController!,
-          false,
-        ),
-        onPressed: customizationState?.hasEnabled == true ? () {} : null,
-      ),
-    );
+    return LightDarkBox(child: _buildOudsSuggestionChip(context));
+  }
+
+  Widget _buildOudsSuggestionChip(BuildContext context) {
+    switch (customizationState?.selectedLayout) {
+      case ChipEnumLayout.textOnly:
+        return OudsSuggestionChip(
+          label: ChipCustomizationUtils.getText(customizationState),
+          onPressed: customizationState?.hasEnabled == true ? () {} : null,
+        );
+      case ChipEnumLayout.iconAndText:
+        return OudsSuggestionChip(
+          label: ChipCustomizationUtils.getText(customizationState),
+          avatar: ChipCustomizationUtils.getIcon(
+            customizationState,
+            themeController!,
+            customizationState!.tintedIcon,
+          ),
+          // tinted: customizationState!.tintedIcon,
+          onPressed: customizationState!.hasEnabled == true ? () {} : null,
+        );
+      case ChipEnumLayout.iconOnly:
+        return OudsSuggestionChip.icon(
+          icon: ChipCustomizationUtils.getIcon(
+            customizationState,
+            themeController!,
+            customizationState!.tintedIcon,
+          ),
+          contentDescription: context.l10n.app_components_common_icon_a11y,
+          tinted: customizationState!.tintedIcon,
+          onPressed: customizationState!.hasEnabled == true ? () {} : null,
+        );
+      case null:
+        throw UnimplementedError();
+    }
   }
 }
 
@@ -205,6 +230,23 @@ class _CustomizationContentState extends State<_CustomizationContent> {
               customizationState.selectedLayout = selectedOption;
             });
           },
+        ),
+        Visibility(
+          visible:
+              customizationState.selectedLayout == ChipEnumLayout.iconAndText ||
+              customizationState.selectedLayout == ChipEnumLayout.iconOnly,
+          child: CustomizableChips<TintedEnum>(
+            title: context.l10n.app_components_common_icon_tech,
+            options: customizationState.tintedIconState.list,
+            selectedOption: customizationState.tintedIconState.selected,
+            getText: (option) => option.stringValue(context),
+            onSelected: (selectedOption) {
+              setState(() {
+                customizationState.tintedIcon =
+                    selectedOption == TintedEnum.tinted;
+              });
+            },
+          ),
         ),
         CustomizableTextField(
           title: context.l10n.app_components_common_label_label,

--- a/app/lib/ui/utilities/customizable/tinted_enum.dart
+++ b/app/lib/ui/utilities/customizable/tinted_enum.dart
@@ -1,0 +1,41 @@
+//
+// Software Name: OUDS Flutter
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Software description: Flutter library of reusable graphical components
+//
+
+import 'package:flutter/material.dart';
+import 'package:ouds_flutter_demo/l10n/app_localizations.dart';
+
+/// Represents whether an icon should be displayed tinted (single color, following
+/// the theme color) or untinted (original, potentially multi-color, asset colors).
+///
+/// Shared between components exposing a `tinted` customization option, such as
+/// [OudsButton] and [OudsLink].
+enum TintedEnum {
+  tinted,
+  untinted;
+
+  static String enumName(BuildContext context) {
+    return context.l10n.app_components_common_tinted_tech;
+  }
+}
+
+extension CustomElementTinted on TintedEnum {
+  String stringValue(BuildContext context) {
+    final l10n = context.l10n;
+
+    switch (this) {
+      case TintedEnum.tinted:
+        return l10n.app_components_common_tinted_tech;
+      case TintedEnum.untinted:
+        return l10n.app_components_common_untinted_tech;
+    }
+  }
+}

--- a/ouds_core/CHANGELOG.md
+++ b/ouds_core/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Library] Create component - `List item` ([#54](https://github.com/Orange-OpenSource/ouds-flutter/issues/54))
 ### Changed
+- [Library] In library, update chips components to v1.5.0 ([#837](https://github.com/Orange-OpenSource/ouds-flutter/issues/837))
 - [Library] Add typography Tokens component ([#905](https://github.com/Orange-OpenSource/ouds-flutter/issues/905))
 - [Library] update icons to use the icons pack 2.3.0 ([#863](https://github.com/Orange-OpenSource/ouds-flutter/issues/863))
 - [Library] In library, update `link` component to v2.4.0 ([#861](https://github.com/Orange-OpenSource/ouds-flutter/issues/861))

--- a/ouds_core/README.md
+++ b/ouds_core/README.md
@@ -96,7 +96,7 @@ It is intended to replace internal frameworks and the previous [ODS](https://git
     </tr>
     <tr>
       <td style="padding:10px;">Filter Chip</td>
-      <td>1.4.0</td>
+      <td>1.5.0</td>
     </tr>
     <tr>
       <td style="padding:10px;">Inline Alert</td>
@@ -153,6 +153,10 @@ It is intended to replace internal frameworks and the previous [ODS](https://git
     <tr>
       <td>Static list item</td>
       <td>0.1.0</td>
+    </tr>
+    <tr>
+      <td style="padding:10px;">Suggestion chip</td>
+      <td>1.5.0</td>
     </tr>
     <tr>
       <td style="padding:10px;">Switch</td>

--- a/ouds_core/lib/components/chip/ouds_filter_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_filter_chip.dart
@@ -39,7 +39,7 @@ enum OudsChipStyle { defaultStyle, selected }
 ///
 /// [OUDS Chip design guidelines](https://r.orange.fr/r/S-ouds-doc-filter-chip)
 ///
-/// **Reference design version : 1.4.0**
+/// **Reference design version : 1.5.0**
 ///
 /// Filter chip is a UI element that allows to select or deselect an option within a series, and is commonly used to capture filtering decisions.
 /// Filter chip allows to filter content by being selected or deselected. It can be toggled "On" or "Off" to refine displayed results,
@@ -162,8 +162,9 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
   }
 
   void _handleFocusChange(bool focus) {
-    if (widget.onSelected == null)
+    if (widget.onSelected == null) {
       _isFocused = false; // Ignore focus changes if disabled
+    }
     setState(() => _isFocused = focus);
   }
 
@@ -553,7 +554,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                   child: ExcludeSemantics(
                     child: Text(
                       widget.label ?? "",
-                      textAlign: TextAlign.center,
+                      textAlign: TextAlign.start,
                       style: OudsTheme.of(context).typographyTokens
                           .typeLabelModerateMedium(context)
                           .copyWith(
@@ -668,7 +669,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                   child: ExcludeSemantics(
                     child: Text(
                       widget.label ?? "",
-                      textAlign: TextAlign.center,
+                      textAlign: TextAlign.start,
                       style: OudsTheme.of(context).typographyTokens
                           .typeLabelModerateMedium(context)
                           .copyWith(

--- a/ouds_core/lib/components/chip/ouds_filter_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_filter_chip.dart
@@ -49,8 +49,15 @@ enum OudsChipStyle { defaultStyle, selected }
 /// Other layouts are available for this component: *text + icon* and *icon only*.
 ///
 /// Parameters:
-/// - [label]: Label displayed in the suggestion chip which describes the chip option.
-/// - [avatar]: Icon displayed in the suggestion chip. Works well with universally recognized symbols, such as a heart for favorites or a checkmark for selection.
+/// - [label]: Text label displayed in the chip.
+/// - [avatar]: Icon displayed in the chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
+/// - [icon]: Icon displayed in the chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
+/// - [selected]: Whether this chip is selected or not. If this value is null so the component is in disabled state.
+/// - [onSelected] : Called when this chip is clicked. A null value indicates that the component is disabled.
+/// - [contentDescription] : Description of the chip's content for accessibility purposes. This value is ignored if the chip also contains a label.
+/// - [tinted] : Controls whether the icon should be tinted with the theme color. Defaults to `true`.
+///   When set to `false`, the icon is displayed with its original colors (e.g., for multi-color icons).
+///   Note that untinted icons must ensure sufficient contrast with the background for accessibility reasons.
 ///
 /// ### You can use [OudsFilterChip] component in your project, customizing parameters as needed :
 ///
@@ -66,58 +73,72 @@ enum OudsChipStyle { defaultStyle, selected }
 ///     );
 /// ```
 ///
+/// **Text with icon filter chip :**
+///
+/// ```dart
+/// OudsFilterChip.icon(
+///   label: 'Label',
+///   icon: 'assets/ic_chip_heart.svg',
+///   selected: true,
+///   onSelected: (bool selected) {},
+/// )
+/// ```
 ///
 class OudsFilterChip extends StatefulWidget {
   final String? label;
+  @Deprecated(
+    "This parameter is deprecated and will be removed in a future version. Use icon instead.",
+  )
   final String? avatar;
-  final bool? selected;
+  final String? icon;
+  final String? contentDescription;
+  final bool selected;
   final ValueChanged<bool>? onSelected;
+  final bool tinted;
 
+  /// Creates a text-only [OudsFilterChip].
+  ///
+  /// This is the default constructor. The [label] parameter must be provided to display the text.
   const OudsFilterChip({
     super.key,
     this.label,
     this.avatar,
-    this.selected,
+    this.selected = false,
     this.onSelected,
-  });
+  }) : tinted = true,
+       contentDescription = null,
+       icon = null;
 
-  static Widget buildIcon(
-    BuildContext context,
-    String assetName,
-    OudsChipControlState controlItemState,
-    bool selected,
-  ) {
-    final controlIconModifier = OudsChipControlIconColorModifier(context);
-    final sizeIcon = OudsTheme.of(
-      context,
-    ).componentsTokens(context).chip.sizeIcon;
-    return SvgPicture.asset(
-      assetName,
-      fit: BoxFit.contain,
-      width: sizeIcon,
-      height: sizeIcon,
-      colorFilter: ColorFilter.mode(
-        controlIconModifier.getIconColor(
-          controlItemState,
-          selected,
-        ), //selected always true when buildIcon
-        BlendMode.srcIn,
-      ),
-    );
-  }
+  /// Creates an [OudsFilterChip] with a text and an icon.
+  ///
+  /// Use this constructor to display an [icon] alongside the [label].
+  /// If only an icon is provided (without a label), it acts as an icon-only chip.
+  const OudsFilterChip.icon({
+    super.key,
+    this.label,
+    this.icon,
+    this.tinted = true,
+    this.selected = false,
+    this.onSelected,
+    this.contentDescription,
+  }) : avatar = null;
 
   @override
   State<OudsFilterChip> createState() => _OudsFilterChipState();
 
   /// Property that detects and returns the chip layout based on the provided elements (text and/or icon)
-  OudsChipLayout get layout => _detectLayout(label, avatar);
+  OudsChipLayout get layout => _detectLayout(label, avatar, icon);
 
-  static OudsChipLayout _detectLayout(String? label, String? icon) {
-    if (label != null && icon != null) {
+  static OudsChipLayout _detectLayout(
+    String? label,
+    String? avatar,
+    String? icon,
+  ) {
+    if (label != null && (icon != null || avatar != null)) {
       return OudsChipLayout.iconAndText;
     } else if (label != null) {
       return OudsChipLayout.textOnly;
-    } else if (icon != null) {
+    } else if (icon != null || avatar != null) {
       return OudsChipLayout.iconOnly;
     }
     return OudsChipLayout.textOnly;
@@ -222,6 +243,9 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     final l10n = OudsLocalizations.of(context);
     final enabled = widget.onSelected != null;
 
+    String? accessibilityLabel = widget.label == null && widget.icon != null
+        ? widget.contentDescription
+        : widget.label;
     String? accessibilityHint;
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
@@ -235,7 +259,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     return Semantics(
       button: true,
       enabled: enabled,
-      label: widget.label,
+      label: accessibilityLabel,
       selected: widget.selected,
       hint: accessibilityHint,
       child: Material(
@@ -249,7 +273,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
             onTap: isDisabled
                 ? null
                 : () {
-                    updateSelectedData();
+                    _updateSelectedData();
                   },
             splashColor: Colors.transparent,
             highlightColor: Colors.transparent,
@@ -394,7 +418,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               border: chipBorderModifier.getBorder(
                 chipState,
                 _isHighContrast,
-                widget.selected!,
+                widget.selected,
               ),
               borderRadius: BorderRadius.circular(
                 OudsTheme.of(
@@ -411,10 +435,10 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
             OudsTheme.of(context).componentsTokens(context).chip.borderRadius,
           ),
           child: Container(
-            width: !widget.selected! ? chipToken.sizeMinWidth : null,
+            width: !widget.selected ? chipToken.sizeMinWidth : null,
             color: chipBgColorModifier.getBackgroundColor(
               chipState,
-              widget.selected!,
+              widget.selected,
             ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlockIconOnly,
@@ -426,12 +450,12 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: widget.selected!
+              spacing: widget.selected
                   ? chipToken.spaceColumnGapIcon
                   : theme.spaceScheme(context).fixedNone,
               children: [
                 Visibility(
-                  visible: widget.selected!,
+                  visible: widget.selected,
                   child: ExcludeSemantics(
                     child: SvgPicture.asset(
                       AppAssets.icons.componentChipTick,
@@ -454,11 +478,11 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                   ),
                 ),
                 ExcludeSemantics(
-                  child: OudsFilterChip.buildIcon(
+                  child: _buildIcon(
                     context,
-                    widget.avatar!,
+                    widget.avatar ?? widget.icon ?? "",
                     chipState,
-                    widget.selected!,
+                    widget.selected,
                   ),
                 ),
               ],
@@ -492,7 +516,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               border: chipBorderModifier.getBorder(
                 chipState,
                 _isHighContrast,
-                widget.selected!,
+                widget.selected,
               ),
               borderRadius: BorderRadius.circular(
                 OudsTheme.of(
@@ -512,7 +536,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
             //margin: EdgeInsets.all(1),
             color: chipBgColorModifier.getBackgroundColor(
               chipState,
-              widget.selected!,
+              widget.selected,
             ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlock,
@@ -527,7 +551,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                if (widget.selected!) ...[
+                if (widget.selected) ...[
                   ExcludeSemantics(
                     child: SvgPicture.asset(
                       AppAssets.icons.componentChipTick,
@@ -561,7 +585,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                             color: chipTextColorModifier.getTextColor(
                               chipState,
                               _isHighContrast,
-                              widget.selected!,
+                              widget.selected,
                             ),
                           ),
                     ),
@@ -569,11 +593,11 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                 ),
                 SizedBox(width: chipToken.spaceColumnGapIcon),
                 ExcludeSemantics(
-                  child: OudsFilterChip.buildIcon(
+                  child: _buildIcon(
                     context,
-                    widget.avatar!,
+                    widget.avatar ?? widget.icon ?? "",
                     chipState,
-                    widget.selected!,
+                    widget.selected,
                   ),
                 ),
               ],
@@ -608,7 +632,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               border: chipBorderModifier.getBorder(
                 chipState,
                 _isHighContrast,
-                widget.selected!,
+                widget.selected,
               ),
               borderRadius: BorderRadius.circular(
                 OudsTheme.of(
@@ -627,7 +651,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
           child: Container(
             color: chipBgColorModifier.getBackgroundColor(
               chipState,
-              widget.selected!,
+              widget.selected,
             ),
             padding: EdgeInsetsDirectional.only(
               top: chipToken.spacePaddingBlock,
@@ -642,7 +666,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                if (widget.selected!) ...[
+                if (widget.selected) ...[
                   ExcludeSemantics(
                     child: SvgPicture.asset(
                       width: MediaQuery.textScalerOf(
@@ -676,7 +700,7 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
                             color: chipTextColorModifier.getTextColor(
                               chipState,
                               _isHighContrast,
-                              widget.selected!,
+                              widget.selected,
                             ),
                           ),
                     ),
@@ -732,15 +756,48 @@ class _OudsFilterChipState extends State<OudsFilterChip> {
     }
   }
 
-  void updateSelectedData() {
+  void _updateSelectedData() {
     _isSelected = !_isSelected;
     // Added to improve visual rendering fluidity by allowing Flutter
     // to complete the current frame before executing the state change logic.
     SchedulerBinding.instance.addPostFrameCallback((_) {
       bool? newValue;
-      newValue = !widget.selected!;
+      newValue = !widget.selected;
       widget.onSelected!(newValue);
-      widget.selected! == newValue;
+      widget.selected == newValue;
     });
+  }
+
+  Widget _buildIcon(
+    BuildContext context,
+    String assetName,
+    OudsChipControlState controlItemState,
+    bool selected,
+  ) {
+    final controlIconModifier = OudsChipControlIconColorModifier(context);
+    final sizeIcon = OudsTheme.of(
+      context,
+    ).componentsTokens(context).chip.sizeIcon;
+    return Container(
+      color: widget.tinted
+          ? null
+          : OudsTheme.of(context).colorScheme(context).surfaceBrandPrimary,
+      child: SvgPicture.asset(
+        matchTextDirection: true,
+        assetName,
+        fit: BoxFit.contain,
+        width: sizeIcon,
+        height: sizeIcon,
+        colorFilter: widget.tinted
+            ? ColorFilter.mode(
+                controlIconModifier.getIconColor(
+                  controlItemState,
+                  selected,
+                ), //selected always true when buildIcon
+                BlendMode.srcIn,
+              )
+            : null,
+      ),
+    );
   }
 }

--- a/ouds_core/lib/components/chip/ouds_filter_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_filter_chip.dart
@@ -15,7 +15,7 @@ library;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_svg/svg.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ouds_accessibility_plugin/ouds_accessibility_plugin.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_background_modifier.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_border_modifier.dart';
@@ -50,7 +50,6 @@ enum OudsChipStyle { defaultStyle, selected }
 ///
 /// Parameters:
 /// - [label]: Text label displayed in the chip.
-/// - [avatar]: Icon displayed in the chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
 /// - [icon]: Icon displayed in the chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
 /// - [selected]: Whether this chip is selected or not. If this value is null so the component is in disabled state.
 /// - [onSelected] : Called when this chip is clicked. A null value indicates that the component is disabled.
@@ -87,7 +86,7 @@ enum OudsChipStyle { defaultStyle, selected }
 class OudsFilterChip extends StatefulWidget {
   final String? label;
   @Deprecated(
-    "This parameter is deprecated and will be removed in a future version. Use icon instead.",
+    "This parameter is deprecated and will be removed in a future version. Use icon instead in OudsFilterChip.icon constructor .",
   )
   final String? avatar;
   final String? icon;
@@ -102,6 +101,9 @@ class OudsFilterChip extends StatefulWidget {
   const OudsFilterChip({
     super.key,
     this.label,
+    @Deprecated(
+      "This parameter is deprecated and will be removed in a future version. Use icon instead in OudsFilterChip.icon constructor .",
+    )
     this.avatar,
     this.selected = false,
     this.onSelected,

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -36,7 +36,7 @@ enum OudsChipStyle { defaultStyle, selected }
 ///
 /// [OUDS Chip design guidelines](https://r.orange.fr/r/S-ouds-doc-suggestion-chip)
 ///
-/// **Reference design version : 1.4.0**
+/// **Reference design version : 1.5.0**
 ///
 /// Suggestion chip is a UI element that allows to present recommended or predictive options
 /// based on user’s input or context, and is commonly used to capture filtering decisions.
@@ -452,7 +452,7 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                   Flexible(
                     child: Text(
                       widget.label ?? "",
-                      textAlign: TextAlign.center,
+                      textAlign: TextAlign.start,
                       style: OudsTheme.of(context).typographyTokens
                           .typeLabelModerateMedium(context)
                           .copyWith(
@@ -525,7 +525,7 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                   Flexible(
                     child: Text(
                       widget.label ?? "",
-                      textAlign: TextAlign.center,
+                      textAlign: TextAlign.start,
                       style: OudsTheme.of(context).typographyTokens
                           .typeLabelModerateMedium(context)
                           .copyWith(

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -47,6 +47,11 @@ enum OudsChipStyle { defaultStyle, selected }
 /// Parameters:
 /// - [label]: Label displayed in the suggestion chip which describes the chip option.
 /// - [avatar]: Icon displayed in the suggestion chip. Works well with universally recognized symbols, such as a heart for favorites or a checkmark for selection.
+/// - [icon]: Icon displayed in the suggestion chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
+/// - [contentDescription] : Description of the chip's content for accessibility purposes. This value is ignored if the chip also contains a label.
+/// - [tinted] : Controls whether the icon should be tinted with the theme color. Defaults to `true`.
+///   When set to `false`, the icon is displayed with its original colors (e.g., for multi-color icons).
+///   Note that untinted icons must ensure sufficient contrast with the background for accessibility reasons.
 /// - [onPressed]: Callback invoked when the suggestion chip is clicked.
 ///
 /// ### You can use [OudsSuggestionChip] component in your project, customizing parameters as needed :
@@ -62,31 +67,64 @@ enum OudsChipStyle { defaultStyle, selected }
 ///     );
 /// ```
 ///
+/// **Text with icon suggestion chip :**
+///
+/// ```dart
+/// OudsSuggestionChip.icon(
+///   label: 'Label',
+///   icon: 'assets/ic_chip_heart.svg',
+///   onPressed: () {},
+/// )
+/// ```
 ///
 class OudsSuggestionChip extends StatefulWidget {
   final String? label;
+  @Deprecated(
+    "This parameter is deprecated and will be removed in a future version. Use icon instead.",
+  )
   final String? avatar;
+  final String? icon;
+  final String? contentDescription;
+  final bool tinted;
   final VoidCallback? onPressed;
 
-  const OudsSuggestionChip({
+  /// Creates a text-only [OudsSuggestionChip].
+  ///
+  /// This is the default constructor. The [label] parameter must be provided to display the text.
+  const OudsSuggestionChip({super.key, this.label, this.avatar, this.onPressed})
+    : tinted = true,
+      contentDescription = null,
+      icon = null;
+
+  /// Creates an [OudsSuggestionChip] with a text and an icon.
+  ///
+  /// Use this constructor to display an [icon] alongside the [label].
+  /// If only an icon is provided (without a label), it acts as an icon-only chip.
+  const OudsSuggestionChip.icon({
     super.key,
     this.label,
-    this.avatar,
+    this.icon,
+    this.tinted = true,
     this.onPressed,
-  });
+    this.contentDescription,
+  }) : avatar = null;
 
   @override
   State<OudsSuggestionChip> createState() => _OudsSuggestionChipState();
 
   /// Property that detects and returns the chip layout based on the provided elements (text and/or icon)
-  OudsChipLayout get layout => _detectLayout(label, avatar);
+  OudsChipLayout get layout => _detectLayout(label, avatar, icon);
 
-  static OudsChipLayout _detectLayout(String? label, String? icon) {
-    if (label != null && icon != null) {
+  static OudsChipLayout _detectLayout(
+    String? label,
+    String? avatar,
+    String? icon,
+  ) {
+    if (label != null && (icon != null || avatar != null)) {
       return OudsChipLayout.iconAndText;
     } else if (label != null) {
       return OudsChipLayout.textOnly;
-    } else if (icon != null) {
+    } else if (icon != null || avatar != null) {
       return OudsChipLayout.iconOnly;
     }
     return OudsChipLayout.textOnly;
@@ -339,7 +377,7 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
     final l10n = OudsLocalizations.of(context);
 
     return Semantics(
-      label: l10n?.core_chip_chip_icon_a11y,
+      label: widget.contentDescription ?? l10n?.core_chip_chip_icon_a11y,
       button: true,
       enabled: widget.onPressed != null,
       child: Stack(
@@ -381,7 +419,11 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   ExcludeSemantics(
-                    child: _buildIcon(context, widget.avatar!, chipState),
+                    child: _buildIcon(
+                      context,
+                      widget.avatar ?? widget.icon ?? "",
+                      chipState,
+                    ),
                   ),
                 ],
               ),
@@ -446,7 +488,11 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   ExcludeSemantics(
-                    child: _buildIcon(context, widget.avatar!, chipState),
+                    child: _buildIcon(
+                      context,
+                      widget.avatar ?? widget.icon ?? "",
+                      chipState,
+                    ),
                   ),
                   SizedBox(width: chipToken.spaceColumnGapIcon),
                   Flexible(
@@ -553,15 +599,29 @@ class _OudsSuggestionChipState extends State<OudsSuggestionChip> {
     OudsChipControlState controlItemState,
   ) {
     final controlIconModifier = OudsChipControlIconColorModifier(context);
+    final sizeIcon = OudsTheme.of(
+      context,
+    ).componentsTokens(context).chip.sizeIcon;
 
-    return SvgPicture.asset(
-      assetName,
-      fit: BoxFit.contain,
-      width: OudsTheme.of(context).componentsTokens(context).chip.sizeIcon,
-      height: OudsTheme.of(context).componentsTokens(context).chip.sizeIcon,
-      colorFilter: ColorFilter.mode(
-        controlIconModifier.getIconColor(controlItemState, _isHighContrast),
-        BlendMode.srcIn,
+    return Container(
+      color: widget.tinted
+          ? null
+          : OudsTheme.of(context).colorScheme(context).surfaceBrandPrimary,
+      child: SvgPicture.asset(
+        matchTextDirection: true,
+        assetName,
+        fit: BoxFit.contain,
+        width: sizeIcon,
+        height: sizeIcon,
+        colorFilter: widget.tinted
+            ? ColorFilter.mode(
+                controlIconModifier.getIconColor(
+                  controlItemState,
+                  _isHighContrast,
+                ),
+                BlendMode.srcIn,
+              )
+            : null,
       ),
     );
   }

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -13,7 +13,7 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ouds_accessibility_plugin/ouds_accessibility_plugin.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_background_modifier.dart';
 import 'package:ouds_core/components/chip/internal/ouds_chip_border_modifier.dart';

--- a/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
+++ b/ouds_core/lib/components/chip/ouds_suggestion_chip.dart
@@ -46,7 +46,6 @@ enum OudsChipStyle { defaultStyle, selected }
 ///
 /// Parameters:
 /// - [label]: Label displayed in the suggestion chip which describes the chip option.
-/// - [avatar]: Icon displayed in the suggestion chip. Works well with universally recognized symbols, such as a heart for favorites or a checkmark for selection.
 /// - [icon]: Icon displayed in the suggestion chip. Use an icon to add additional affordance where the icon has a clear and well-established meaning.
 /// - [contentDescription] : Description of the chip's content for accessibility purposes. This value is ignored if the chip also contains a label.
 /// - [tinted] : Controls whether the icon should be tinted with the theme color. Defaults to `true`.
@@ -80,7 +79,7 @@ enum OudsChipStyle { defaultStyle, selected }
 class OudsSuggestionChip extends StatefulWidget {
   final String? label;
   @Deprecated(
-    "This parameter is deprecated and will be removed in a future version. Use icon instead.",
+    "This parameter is deprecated and will be removed in a future version. Use icon instead in OudsSuggestionChip.icon constructor .",
   )
   final String? avatar;
   final String? icon;
@@ -91,10 +90,17 @@ class OudsSuggestionChip extends StatefulWidget {
   /// Creates a text-only [OudsSuggestionChip].
   ///
   /// This is the default constructor. The [label] parameter must be provided to display the text.
-  const OudsSuggestionChip({super.key, this.label, this.avatar, this.onPressed})
-    : tinted = true,
-      contentDescription = null,
-      icon = null;
+  const OudsSuggestionChip({
+    super.key,
+    this.label,
+    @Deprecated(
+      "This parameter is deprecated and will be removed in a future version. Use icon instead in OudsSuggestionChip.icon constructor .",
+    )
+    this.avatar,
+    this.onPressed,
+  }) : tinted = true,
+       contentDescription = null,
+       icon = null;
 
   /// Creates an [OudsSuggestionChip] with a text and an icon.
   ///

--- a/skills/ouds-flutter-framework-usage/SKILL.md
+++ b/skills/ouds-flutter-framework-usage/SKILL.md
@@ -514,11 +514,28 @@ OudsFilterChip(
   onSelected: (selected) {},
 )
 
+OudsFilterChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  tinted: true,
+  selected: true,
+  onSelected: (selected) {},
+)
+
 OudsSuggestionChip(
   label: 'Label',
   onPressed: () {},
 )
+
+OudsSuggestionChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  tinted: true,
+  onPressed: () {},
+)
 ```
+
+> `avatar` is deprecated on both `OudsFilterChip` and `OudsSuggestionChip` default constructors — use the `.icon` named constructor with its `icon` parameter instead.
 
 ---
 

--- a/skills/ouds-flutter-migration-guide/SKILL.md
+++ b/skills/ouds-flutter-migration-guide/SKILL.md
@@ -681,7 +681,7 @@ Before proposing changes:
 
 | Migration | Compatibility | Migration required | Main topics |
 |-----------|---------------|--------------------|-------------|
-| `v1.3.1 → v2.0.0` | Partial | Yes for deprecated APIs | `OudsLink` named constructors (`.icon`, `.previous`, `.next`, `.external`), Markdown support, token/icon updates |
+| `v1.3.1 → v2.0.0` | Partial | Yes for deprecated APIs | `OudsLink` named constructors (`.icon`, `.previous`, `.next`, `.external`), `OudsFilterChip.icon` (`avatar` deprecated), Markdown support, token/icon updates |
 | `v1.3.0 → v1.3.1` | Full | No | Maintenance release, bug fixes, accessibility improvements |
 | `v1.2.0 → v1.3.0` | Partial | Yes for deprecated APIs | `OudsTag` named constructors, `OudsBadge` named constructors, `OudsPinCodeInput.keyboardType`, new alert/bottom-sheet components |
 | `v1.1.x → v1.2.0` | No | Yes | `OudsTagConfig` removal from theme config, status icon updates, top bar components, French support |
@@ -730,6 +730,38 @@ OudsLink.external(label: 'Label')
 - Use `OudsLink.external(...)` for links navigating outside the current product, service or application.
 - Text-only links keep using the default `OudsLink(...)` constructor unchanged.
 - The deprecated `layout` (`OudsLinkLayout`) parameter on the default constructor still works but should be migrated.
+
+---
+
+#### 3.3.0bis `OudsFilterChip` → `avatar` deprecated in favor of `OudsFilterChip.icon` (`v1.3.1 → v2.0.0`)
+
+**Before:**
+
+```dart
+OudsFilterChip(
+  label: 'Label',
+  avatar: 'assets/ic_chip_heart.svg',
+  selected: true,
+  onSelected: (bool selected) {},
+)
+```
+
+**After:**
+
+```dart
+OudsFilterChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  selected: true,
+  onSelected: (bool selected) {},
+)
+```
+
+**Required actions:**
+
+- Replace `OudsFilterChip(avatar: ...)` with `OudsFilterChip.icon(icon: ...)`.
+- Text-only filter chips keep using the default `OudsFilterChip(...)` constructor unchanged.
+- The deprecated `avatar` parameter on the default constructor still works but should be migrated.
 
 ---
 

--- a/skills/ouds-flutter-migration-guide/SKILL.md
+++ b/skills/ouds-flutter-migration-guide/SKILL.md
@@ -681,7 +681,7 @@ Before proposing changes:
 
 | Migration | Compatibility | Migration required | Main topics |
 |-----------|---------------|--------------------|-------------|
-| `v1.3.1 → v2.0.0` | Partial | Yes for deprecated APIs | `OudsLink` named constructors (`.icon`, `.previous`, `.next`, `.external`), `OudsFilterChip.icon` (`avatar` deprecated), Markdown support, token/icon updates |
+| `v1.3.1 → v2.0.0` | Partial | Yes for deprecated APIs | `OudsLink` named constructors (`.icon`, `.previous`, `.next`, `.external`), `OudsFilterChip.icon` (`avatar` deprecated), `OudsSuggestionChip.icon` (`avatar` deprecated), Markdown support, token/icon updates |
 | `v1.3.0 → v1.3.1` | Full | No | Maintenance release, bug fixes, accessibility improvements |
 | `v1.2.0 → v1.3.0` | Partial | Yes for deprecated APIs | `OudsTag` named constructors, `OudsBadge` named constructors, `OudsPinCodeInput.keyboardType`, new alert/bottom-sheet components |
 | `v1.1.x → v1.2.0` | No | Yes | `OudsTagConfig` removal from theme config, status icon updates, top bar components, French support |
@@ -761,6 +761,37 @@ OudsFilterChip.icon(
 
 - Replace `OudsFilterChip(avatar: ...)` with `OudsFilterChip.icon(icon: ...)`.
 - Text-only filter chips keep using the default `OudsFilterChip(...)` constructor unchanged.
+- The deprecated `avatar` parameter on the default constructor still works but should be migrated.
+
+---
+
+#### 3.3.0ter `OudsSuggestionChip` → `avatar` deprecated in favor of `OudsSuggestionChip.icon` (`v1.3.1 → v2.0.0`)
+
+**Before:**
+
+```dart
+OudsSuggestionChip(
+  label: 'Label',
+  avatar: 'assets/ic_chip_heart.svg',
+  onPressed: () {},
+)
+```
+
+**After:**
+
+```dart
+OudsSuggestionChip.icon(
+  label: 'Label',
+  icon: 'assets/ic_chip_heart.svg',
+  tinted: true,
+  onPressed: () {},
+)
+```
+
+**Required actions:**
+
+- Replace `OudsSuggestionChip(avatar: ...)` with `OudsSuggestionChip.icon(icon: ...)`.
+- Text-only suggestion chips keep using the default `OudsSuggestionChip(...)` constructor unchanged.
 - The deprecated `avatar` parameter on the default constructor still works but should be migrated.
 
 ---


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

- #837 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring (non-breaking change)
- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [X] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- NA My change follows accessibility good practices

#### Design

- [X] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [X] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-flutter/blob/develop/.github/DEVELOP.md)
- NA I have added unit tests to cover my changes _(optional)_

#### Documentation

- [X] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [X] Manually test (dark mode, RTL, landscape display, tablet)
- [X] Documentation has been updated if relevant
- [ ] Design review
- [ ] A11y review
- NA Internal files have been updated if relevant (THIRD_PARTY, NOTICE)
- [X] CHANGELOG.md files have been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and referencing the issue
